### PR TITLE
Dtype reimplementation

### DIFF
--- a/src/nested_pandas/series/dtype.py
+++ b/src/nested_pandas/series/dtype.py
@@ -2,73 +2,52 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import cast
+
+# We use Type, because we must use "type" as an attribute name
+from typing import Type, cast  # noqa: UP035
 
 import pandas as pd
 import pyarrow as pa
 from pandas import ArrowDtype
 from pandas.api.extensions import register_extension_dtype
-from pandas.core.arrays import ArrowExtensionArray
+from pandas.core.arrays import ExtensionArray
+from pandas.core.dtypes.base import ExtensionDtype
 
+from nested_pandas.series.na import NA, NAType
 from nested_pandas.series.utils import is_pa_type_a_list
 
 __all__ = ["NestedDtype"]
 
 
 @register_extension_dtype
-class NestedDtype(ArrowDtype):
+class NestedDtype(ExtensionDtype):
     """Data type to handle packed time series data"""
 
-    pyarrow_dtype: pa.StructType
+    # ExtensionDtype overrides #
 
-    def __init__(self, pyarrow_dtype: pa.DataType) -> None:
-        pyarrow_dtype = self._validate_dtype(pyarrow_dtype)
-        super().__init__(pyarrow_dtype=pyarrow_dtype)
+    _metadata = ("pyarrow_dtype",)
+    """Attributes to use as metadata for __eq__ and __hash__"""
+
+    @property
+    def na_value(self) -> NAType:
+        """The missing value for this dtype"""
+        return NA
+
+    type = pd.DataFrame
+    """The type of the array's elements, always pd.DataFrame"""
+
+    @property
+    def name(self) -> str:
+        """The string representation of the nested type"""
+        fields = ", ".join([f"{field.name}: [{field.type.value_type!s}]" for field in self.pyarrow_dtype])
+        return f"nested<{fields}>"
 
     @classmethod
-    def from_fields(cls, fields: Mapping[str, pa.DataType]) -> Self:  # type: ignore[name-defined] # noqa: F821
-        """Make NestedDtype from a mapping of field names and list item types.
+    def construct_array_type(cls) -> Type[ExtensionArray]:
+        """Corresponded array type, always NestedExtensionArray"""
+        from nested_pandas.series.ext_array import NestedExtensionArray
 
-        Parameters
-        ----------
-        fields : Mapping[str, pa.DataType]
-            A mapping of field names and their item types. Since all fields are lists, the item types are
-            inner types of the lists, not the list types themselves.
-
-        Returns
-        -------
-        NestedDtype
-            The constructed NestedDtype.
-
-        Examples
-        --------
-        >>> dtype = NestedDtype.from_fields({"a": pa.float64(), "b": pa.int64()})
-        >>> dtype
-        nested<a: [double], b: [int64]>
-        >>> assert (
-        ...     dtype.pyarrow_dtype
-        ...     == pa.struct({"a": pa.list_(pa.float64()), "b": pa.list_(pa.int64())})
-        ... )
-        """
-        pyarrow_dtype = pa.struct({field: pa.list_(pa_type) for field, pa_type in fields.items()})
-        pyarrow_dtype = cast(pa.StructType, pyarrow_dtype)
-        return cls(pyarrow_dtype=pyarrow_dtype)
-
-    @staticmethod
-    def _validate_dtype(pyarrow_dtype: pa.DataType) -> pa.StructType:
-        if not isinstance(pyarrow_dtype, pa.DataType):
-            raise TypeError(f"Expected a 'pyarrow.DataType' object, got {type(pyarrow_dtype)}")
-        if not pa.types.is_struct(pyarrow_dtype):
-            raise ValueError("NestedDtype can only be constructed with pyarrow struct type.")
-        pyarrow_dtype = cast(pa.StructType, pyarrow_dtype)
-
-        for field in pyarrow_dtype:
-            if not is_pa_type_a_list(field.type):
-                raise ValueError(
-                    "NestedDtype can only be constructed with pyarrow struct type, all fields must be list "
-                    f"type. Given struct has unsupported field {field}"
-                )
-        return pyarrow_dtype
+        return NestedExtensionArray
 
     @classmethod
     def construct_from_string(cls, string: str) -> Self:  # type: ignore[name-defined] # noqa: F821
@@ -135,6 +114,91 @@ class NestedDtype(ArrowDtype):
 
         return cls.from_fields(fields)
 
+    # ArrowDtype would return None so we do
+    def _get_common_dtype(self, dtypes: list) -> None:
+        return None
+
+    # Optional methods #
+
+    def __from_arrow__(self, array: pa.Array | pa.ChunkedArray) -> ExtensionArray:
+        """Construct a NestedExtensionArray from a pyarrow array.
+
+        Parameters
+        ----------
+        array : pa.Array | pa.ChunkedArray
+            The input pyarrow array.
+
+        Returns
+        -------
+        NestedExtensionArray
+            The constructed NestedExtensionArray.
+        """
+        from nested_pandas.series.ext_array import NestedExtensionArray
+
+        return NestedExtensionArray(array)
+
+    # Additional methods and attributes #
+
+    pyarrow_dtype: pa.StructType
+
+    def __init__(self, pyarrow_dtype: pa.DataType) -> None:
+        self.pyarrow_dtype = self._validate_dtype(pyarrow_dtype)
+
+    @classmethod
+    def from_fields(cls, fields: Mapping[str, pa.DataType]) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Make NestedDtype from a mapping of field names and list item types.
+
+        Parameters
+        ----------
+        fields : Mapping[str, pa.DataType]
+            A mapping of field names and their item types. Since all fields are lists, the item types are
+            inner types of the lists, not the list types themselves.
+
+        Returns
+        -------
+        NestedDtype
+            The constructed NestedDtype.
+
+        Examples
+        --------
+        >>> dtype = NestedDtype.from_fields({"a": pa.float64(), "b": pa.int64()})
+        >>> dtype
+        nested<a: [double], b: [int64]>
+        >>> assert (
+        ...     dtype.pyarrow_dtype
+        ...     == pa.struct({"a": pa.list_(pa.float64()), "b": pa.list_(pa.int64())})
+        ... )
+        """
+        pyarrow_dtype = pa.struct({field: pa.list_(pa_type) for field, pa_type in fields.items()})
+        pyarrow_dtype = cast(pa.StructType, pyarrow_dtype)
+        return cls(pyarrow_dtype=pyarrow_dtype)
+
+    @staticmethod
+    def _validate_dtype(pyarrow_dtype: pa.DataType) -> pa.StructType:
+        if not isinstance(pyarrow_dtype, pa.DataType):
+            raise TypeError(f"Expected a 'pyarrow.DataType' object, got {type(pyarrow_dtype)}")
+        if not pa.types.is_struct(pyarrow_dtype):
+            raise ValueError("NestedDtype can only be constructed with pyarrow struct type.")
+        pyarrow_dtype = cast(pa.StructType, pyarrow_dtype)
+
+        for field in pyarrow_dtype:
+            if not is_pa_type_a_list(field.type):
+                raise ValueError(
+                    "NestedDtype can only be constructed with pyarrow struct type, all fields must be list "
+                    f"type. Given struct has unsupported field {field}"
+                )
+        return pyarrow_dtype
+
+    @property
+    def fields(self) -> dict[str, pa.DataType]:
+        """The mapping of field names and their item types."""
+        return {field.name: field.type.value_type for field in self.pyarrow_dtype}
+
+    @property
+    def field_names(self) -> list[str]:
+        """The list of field names of the nested type"""
+        return [field.name for field in self.pyarrow_dtype]
+
     @classmethod
     def from_pandas_arrow_dtype(cls, pandas_arrow_dtype: ArrowDtype):
         """Construct NestedDtype from a pandas.ArrowDtype.
@@ -154,21 +218,14 @@ class NestedDtype(ArrowDtype):
         ValueError
             If the given dtype is not a valid nested type.
         """
-        pyarrow_dtype = cls._validate_dtype(pandas_arrow_dtype.pyarrow_dtype)
-        return cls(pyarrow_dtype=pyarrow_dtype)
+        return cls(pyarrow_dtype=pandas_arrow_dtype.pyarrow_dtype)
 
-    @classmethod
-    def construct_array_type(cls) -> type[ArrowExtensionArray]:
-        """Corresponded array type, always NestedExtensionArray"""
-        from nested_pandas.series.ext_array import NestedExtensionArray
+    def to_pandas_arrow_dtype(self) -> ArrowDtype:
+        """Convert NestedDtype to a pandas.ArrowDtype.
 
-        return NestedExtensionArray
-
-    @property
-    def name(self) -> str:
-        """The string representation of the nested type"""
-        fields = ", ".join([f"{field.name}: [{field.type.value_type!s}]" for field in self.pyarrow_dtype])
-        return f"nested<{fields}>"
-
-    type = pd.DataFrame
-    """The type of the array's elements, always pd.DataFrame"""
+        Returns
+        -------
+        ArrowDtype
+            The corresponding pandas.ArrowDtype.
+        """
+        return ArrowDtype(self.pyarrow_dtype)

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -80,6 +80,8 @@ class NestedExtensionArray(ArrowExtensionArray):
         # The previous line may return an iterator, but parent's _from_sequence needs Sequence
         if not isinstance(scalars, Sequence) and isinstance(scalars, Collection):
             scalars = list(scalars)
+        if isinstance(dtype, NestedDtype):
+            dtype = dtype.to_pandas_arrow_dtype()
         return super()._from_sequence(scalars, dtype=dtype, copy=copy)
 
     @staticmethod
@@ -102,6 +104,15 @@ class NestedExtensionArray(ArrowExtensionArray):
                 # compare offsets from the first list array with the current one
                 if not first_list_array.offsets.equals(list_array.offsets):
                     raise ValueError("Offsets of all ListArrays must be the same")
+
+    @classmethod
+    def from_arrow_ext_array(cls, array: ArrowExtensionArray) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Create a NestedExtensionArray from pandas' ArrowExtensionArray"""
+        return cls(array._pa_array)
+
+    def to_arrow_ext_array(self) -> ArrowExtensionArray:
+        """Convert the extension array to pandas' ArrowExtensionArray"""
+        return ArrowExtensionArray(self._pa_array)
 
     def _replace_pa_array(self, pa_array: pa.ChunkedArray, *, validate: bool) -> None:
         if validate:

--- a/src/nested_pandas/series/na.py
+++ b/src/nested_pandas/series/na.py
@@ -1,0 +1,55 @@
+"""Missing value for NestedDtype
+
+It i something between pandas' NA and NaN
+"""
+
+__all__ = ["NAType", "NA"]
+
+
+class _NAType:
+    pass
+
+
+class NAType:
+    """Singleton class representing missing value for NestedDtype.
+
+    It doesn't implement most of the arithmetics and boolean logic operations,
+    because they are ambiguous for missing values.
+
+    The implementation is inspired both by pandas' NA and float number NaN.
+
+    `NA` is a singleton instance of this class.
+    """
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        """Create a new instance of NAType."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "<NA>"
+
+    def __format__(self, format_spec) -> str:
+        try:
+            return self.__repr__().__format__(format_spec)
+        except ValueError:
+            return self.__repr__()
+
+    def __bool__(self):
+        raise TypeError("boolean value of NA is ambiguous")
+
+    def __eq__(self, other):
+        return False
+
+    def __ne__(self, other):
+        return True
+
+    def __hash__(self):
+        return 0
+
+
+NA = NAType()
+"""Missed value for NestedDtype, a singleton instance of `NAType` class."""

--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -46,7 +46,7 @@ def pack_flat_into_df(df: pd.DataFrame, name=None) -> pd.DataFrame:
     """
     # TODO: we can optimize name=None case a bit
     struct_series = pack_flat(df, name=name)
-    packed_df = struct_series.struct.explode()
+    packed_df = struct_series.nest.to_lists()
     if name is not None:
         packed_df[name] = struct_series
     return packed_df

--- a/tests/nested_pandas/series/test_dtype.py
+++ b/tests/nested_pandas/series/test_dtype.py
@@ -1,7 +1,9 @@
+import pandas as pd
 import pyarrow as pa
 import pytest
 from nested_pandas.series.dtype import NestedDtype
 from nested_pandas.series.ext_array import NestedExtensionArray
+from nested_pandas.series.na import NA
 
 
 @pytest.mark.parametrize(
@@ -40,6 +42,14 @@ def test_from_pyarrow_dtype_raises(pyarrow_dtype):
         NestedDtype(pyarrow_dtype)
 
 
+def test_to_pandas_pyarrow_dtype():
+    """Test that NestedDtype.to_pandas_pyarrow_dtype() returns the correct pyarrow struct type."""
+    dtype = NestedDtype.from_fields({"a": pa.int64(), "b": pa.int64()})
+    assert dtype.to_pandas_pyarrow_dtype() == pd.ArrowDtype(
+        pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))])
+    )
+
+
 def test_from_fields():
     """Test NestedDtype.from_fields()."""
     fields = {"a": pa.int64(), "b": pa.float64()}
@@ -47,6 +57,28 @@ def test_from_fields():
     assert dtype.pyarrow_dtype == pa.struct(
         [pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))]
     )
+
+
+def test_na_value():
+    """Test that NestedDtype.na_value is a singleton instance of NAType."""
+    dtype = NestedDtype(pa.struct([pa.field("a", pa.list_(pa.int64()))]))
+    assert dtype.na_value is NA
+
+
+def test_fields():
+    """Test NestedDtype.fields property"""
+    dtype = NestedDtype(
+        pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))])
+    )
+    assert dtype.fields == {"a": pa.int64(), "b": pa.float64()}
+
+
+def test_field_names():
+    """Test NestedDtype.field_names property"""
+    dtype = NestedDtype(
+        pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))])
+    )
+    assert dtype.field_names == ["a", "b"]
 
 
 @pytest.mark.parametrize(

--- a/tests/nested_pandas/series/test_dtype.py
+++ b/tests/nested_pandas/series/test_dtype.py
@@ -42,10 +42,10 @@ def test_from_pyarrow_dtype_raises(pyarrow_dtype):
         NestedDtype(pyarrow_dtype)
 
 
-def test_to_pandas_pyarrow_dtype():
-    """Test that NestedDtype.to_pandas_pyarrow_dtype() returns the correct pyarrow struct type."""
-    dtype = NestedDtype.from_fields({"a": pa.int64(), "b": pa.int64()})
-    assert dtype.to_pandas_pyarrow_dtype() == pd.ArrowDtype(
+def test_to_pandas_arrow_dtype():
+    """Test that NestedDtype.to_pandas_arrow_dtype() returns the correct pyarrow struct type."""
+    dtype = NestedDtype.from_fields({"a": pa.int64(), "b": pa.float64()})
+    assert dtype.to_pandas_arrow_dtype() == pd.ArrowDtype(
         pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))])
     )
 

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -5,6 +5,7 @@ import pytest
 from nested_pandas import NestedDtype
 from nested_pandas.series.ext_array import NestedExtensionArray
 from numpy.testing import assert_array_equal
+from pandas.core.arrays import ArrowExtensionArray
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 
@@ -626,3 +627,33 @@ def test_delete_last_field_raises():
 
     with pytest.raises(ValueError):
         ext_array.pop_field("b")
+
+
+def test_from_arrow_ext_array():
+    """Tests that we can create a NestedExtensionArray from an ArrowExtensionArray."""
+    struct_array = pa.StructArray.from_arrays(
+        arrays=[
+            pa.array([np.array([1, 2, 3]), np.array([1, 2, 1, 2])]),
+            pa.array([-np.array([4.0, 5.0, 6.0]), -np.array([3.0, 4.0, 5.0, 6.0])]),
+        ],
+        names=["a", "b"],
+    )
+    ext_array = ArrowExtensionArray(struct_array)
+
+    from_arrow = NestedExtensionArray.from_arrow_ext_array(ext_array)
+    assert_series_equal(pd.Series(ext_array), pd.Series(from_arrow), check_dtype=False)
+
+
+def test_to_arrow_ext_array():
+    """Tests that we can create an ArrowExtensionArray from a NestedExtensionArray."""
+    struct_array = pa.StructArray.from_arrays(
+        arrays=[
+            pa.array([np.array([1, 2, 3]), np.array([1, 2, 1, 2])]),
+            pa.array([-np.array([4.0, 5.0, 6.0]), -np.array([3.0, 4.0, 5.0, 6.0])]),
+        ],
+        names=["a", "b"],
+    )
+    ext_array = NestedExtensionArray(struct_array)
+
+    to_arrow = ext_array.to_arrow_ext_array()
+    assert_series_equal(pd.Series(ext_array), pd.Series(to_arrow), check_dtype=False)

--- a/tests/nested_pandas/series/test_na.py
+++ b/tests/nested_pandas/series/test_na.py
@@ -1,0 +1,50 @@
+import pytest
+from nested_pandas.series.na import NA
+
+
+def test_na_is_singleton():
+    """Test that NA is a singleton instance"""
+    assert NA is NA
+
+
+def test_na_repr():
+    """Test that NA has the correct representation."""
+    assert repr(NA) == "<NA>"
+
+
+def test_na_format():
+    """Test that NA has the correct format."""
+    assert f"{NA}" == "<NA>"
+
+
+def test_na_bool():
+    """Test that NA raises TypeError when converted to bool."""
+    with pytest.raises(TypeError):
+        bool(NA)
+
+
+def test_na_eq():
+    """Test that NA is not equal to anything."""
+    assert NA != 1
+    assert NA != 1.0
+    assert NA != "1"
+    assert NA != NA
+
+
+def test_na_neq():
+    """Test that NA is not equal to anything."""
+    assert NA != 1
+    assert NA != 1.0
+    assert NA != "1"
+    assert [] != NA
+    assert {} != NA
+    assert NA != ()
+    assert set() != NA
+    assert NA != NA
+    assert object() != NA
+
+
+def test_hash():
+    """Test that hash(NA) is always the same."""
+    assert hash(NA) == hash(NA)
+    assert {NA, NA} == {NA}

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -129,7 +129,7 @@ def test_pack_lists():
     series = packer.pack_lists(packed_df)
 
     for field_name in packed_df.columns:
-        assert_series_equal(series.struct.field(field_name), packed_df[field_name])
+        assert_series_equal(series.nest.get_list_series(field_name), packed_df[field_name])
 
 
 def test_pack_dfs():


### PR DESCRIPTION
The plan is to reimplement both `NestedDtype` and `NestedExtArray` without inheriting pandas' classes, because this requires the use of the internal "protected" pandas' classes.

This PR reimplements `NestedDtype` and introduces `NA`, which is a missed value for the dtype. It also fixes some parts of `NestedExtArray` and adds few more methods, but this one I'll reimplement in the future.

<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->



## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
