### PR TITLE
Initial query wrapping

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -6,6 +6,8 @@ import pandas as pd
 from nested_pandas.series import packer
 from nested_pandas.series.dtype import NestedDtype
 
+from .utils import _ensure_spacing
+
 
 class NestedFrame(pd.DataFrame):
     """A Pandas Dataframe extension with support for nested structure.
@@ -58,3 +60,56 @@ class NestedFrame(pd.DataFrame):
         packed = packer.pack_flat(nested, name=name)
         label = packed.name
         return self.assign(**{f"{label}": packed})
+
+    def _split_query(self, expr) -> dict:
+        """Splits a pandas query into multiple subqueries for nested and base layers"""
+        # Ensure query has needed spacing for upcoming split
+        expr = _ensure_spacing(expr)
+        nest_exprs = {col: [] for col in self.nested_cols + ["base"]}  # type: dict
+        split_expr = expr.split(" ")
+
+        i = 0
+        current_focus = "base"
+        while i < len(split_expr):
+            expr_slice = split_expr[i].strip("()")
+            # Check if it's a nested column
+            if self._is_known_hierarchical_column(expr_slice):
+                nested, colname = split_expr[i].split(".")
+                current_focus = nested.strip("()")
+                # account for parentheses
+                j = 0
+                while j < len(nested):
+                    if nested[j] == "(":
+                        nest_exprs[current_focus].append("(")
+                    j += 1
+                nest_exprs[current_focus].append(colname)
+            # or if it's a top-level column
+            elif expr_slice in self.columns:
+                current_focus = "base"
+                nest_exprs[current_focus].append(split_expr[i])
+            else:
+                nest_exprs[current_focus].append(split_expr[i])
+            i += 1
+        return {expr: " ".join(nest_exprs[expr]) for expr in nest_exprs if len(nest_exprs[expr]) > 0}
+
+    def query(self, expr) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """overwrite query to first check which columns should be queried"""
+
+        # Rebuild queries for each specified nested/base layer
+        exprs_to_use = self._split_query(expr)
+
+        # For now (simplicity), limit query to only operating on one layer
+        if len(exprs_to_use.keys()) != 1:
+            raise ValueError("Queries cannot target multiple structs/layers, write a separate query for each")
+
+        # Send queries to layers
+        # We'll only execute 1 per the Error above, but the loop will be useful
+        # for when/if we allow multi-layer queries
+        result = self.copy()
+        for expr in exprs_to_use:
+            if expr == "base":
+                result = super().query(exprs_to_use["base"], inplace=False)
+            else:
+                # TODO: does not work with queries that empty the dataframe
+                result[expr] = result[expr].ts.query_flat(exprs_to_use[expr])
+        return result

--- a/src/nested_pandas/nestedframe/utils.py
+++ b/src/nested_pandas/nestedframe/utils.py
@@ -1,0 +1,34 @@
+def _ensure_spacing(expr) -> str:
+    """Ensure that an eval string has spacing"""
+    single_val_operators = ["+", "-", "*", "/", "%", ">", "<", "|", "&", "~", "="]  # omit "(" and ")"
+    check_for_doubles = ["=", "/", "*", ">", "<"]
+    double_val_operators = ["==", "//", "**", ">=", "<="]
+    expr_list = [*expr]
+    i = 0
+    spaced_expr = ""
+    while i < len(expr_list):
+        if expr_list[i] not in single_val_operators:
+            spaced_expr += expr_list[i]
+        else:
+            if expr_list[i] in check_for_doubles:
+                if "".join(expr_list[i : i + 2]) in double_val_operators:
+                    if spaced_expr[-1] != " ":
+                        spaced_expr += " "
+                    spaced_expr += "".join(expr_list[i : i + 2])
+                    if expr_list[i + 2] != " ":
+                        spaced_expr += " "
+                    i += 1  # skip ahead an extra time
+                else:
+                    if spaced_expr[-1] != " ":
+                        spaced_expr += " "
+                    spaced_expr += expr_list[i]
+                    if expr_list[i + 1] != " ":
+                        spaced_expr += " "
+            else:
+                if spaced_expr[-1] != " ":
+                    spaced_expr += " "
+                spaced_expr += expr_list[i]
+                if expr_list[i + 1] != " ":
+                    spaced_expr += " "
+        i += 1
+    return spaced_expr

--- a/src/nested_pandas/nestedframe/utils.py
+++ b/src/nested_pandas/nestedframe/utils.py
@@ -1,9 +1,10 @@
 def _ensure_spacing(expr) -> str:
     """Ensure that an eval string has spacing"""
-    single_val_operators = ["+", "-", "*", "/", "%", ">", "<", "|", "&", "~", "="]  # omit "(" and ")"
-    check_for_doubles = ["=", "/", "*", ">", "<"]
-    double_val_operators = ["==", "//", "**", ">=", "<="]
-    expr_list = [*expr]
+    single_val_operators = {"+", "-", "*", "/", "%", ">", "<", "|", "&", "~", "="}  # omit "(" and ")"
+    check_for_doubles = {"=", "/", "*", ">", "<"}
+    double_val_operators = {"==", "//", "**", ">=", "<="}
+    expr_list = expr
+
     i = 0
     spaced_expr = ""
     while i < len(expr_list):

--- a/src/nested_pandas/nestedframe/utils.py
+++ b/src/nested_pandas/nestedframe/utils.py
@@ -15,7 +15,7 @@ def _ensure_spacing(expr) -> str:
                 if "".join(expr_list[i : i + 2]) in double_val_operators:
                     if spaced_expr[-1] != " ":
                         spaced_expr += " "
-                    spaced_expr += "".join(expr_list[i : i + 2])
+                    spaced_expr += expr_list[i : i + 2]
                     if expr_list[i + 2] != " ":
                         spaced_expr += " "
                     i += 1  # skip ahead an extra time

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from nested_pandas import NestedFrame
 
 
@@ -74,3 +75,29 @@ def test_add_nested():
 
     assert "nested" in base.columns
     assert base.nested.nest.to_flat().equals(nested)
+
+
+def test_query():
+    """Test that NestedFrame.query handles nested queries correctly"""
+
+    base = NestedFrame(data={"a": [1, 2, 3], "b": [2, 4, 6]}, index=[0, 1, 2])
+
+    nested = pd.DataFrame(
+        data={"c": [0, 2, 4, 1, 4, 3, 1, 4, 1], "d": [5, 4, 7, 5, 3, 1, 9, 3, 4]},
+        index=[0, 0, 0, 1, 1, 1, 2, 2, 2],
+    )
+
+    # Test vanilla queries
+    base = base.add_nested(nested, "nested")
+    assert len(base.query("a > 2")) == 1
+
+    # Check for the multi-layer error
+    with pytest.raises(ValueError):
+        base.query("a > 2 & nested.c > 1")
+
+    # Test nested queries
+    nest_queried = base.query("nested.c > 1")
+    assert len(nest_queried.nested.nest.to_flat()) == 5
+
+    nest_queried = base.query("nested.c > 1 and nested.d>2")
+    assert len(nest_queried.nested.nest.to_flat()) == 4

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -99,5 +99,5 @@ def test_query():
     nest_queried = base.query("nested.c > 1")
     assert len(nest_queried.nested.nest.to_flat()) == 5
 
-    nest_queried = base.query("nested.c > 1 and nested.d>2")
+    nest_queried = base.query("(nested.c > 1) and (nested.d>2)")
     assert len(nest_queried.nested.nest.to_flat()) == 4

--- a/tests/nested_pandas/nestedframe/test_utils.py
+++ b/tests/nested_pandas/nestedframe/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+from nested_pandas.nestedframe import utils
+
+
+@pytest.mark.parametrize(
+    "in_out",
+    [
+        ("a>3", "a > 3"),
+        ("test.a>5&b==2", "test.a > 5 & b == 2"),
+        ("b > 3", "b > 3"),
+        ("(a.b > 3)&(a.c == 'f')", "(a.b > 3) & (a.c == 'f')"),
+    ],
+)
+def test_ensure_spacing(in_out):
+    """test a set of input queries to make sure spacing is done correctly"""
+    expr, output = in_out
+    assert utils._ensure_spacing(expr) == output


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [x] My PR includes a link to the issue that I am addressing
Addresses #10.


## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
This PR wraps the pandas query function. Before executing any query, it first checks the input query string for spacing between the various components. I needed this to essentially be able to split each component apart and check to see if it was targeting a nested column using the "nested_frame.nested_column" access pattern. It then builds a set of subqueries for each targeted layer. At the moment, I limited this to only having one layer be targetable at a time, but we could allow multiple queries to execute within the query call down the road.

One note, is that using the "." is slightly overloaded in Pandas eval syntax. You can use "column.property" within eval normally. We override this by splitting on it and removing the dot, so some subset of queries full functionality is probably limited. I think this implementation should be sufficient for the MVP however, and we can come back to make this more robust in a later stage of the project.



## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

