### PR TITLE
speedup with to_lists()

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -387,11 +387,11 @@ class NestedFrame(pd.DataFrame):
         for layer in layers:
             if layer == "base":
                 columns = [col[1] for col in requested_columns if col[0] == layer]
-                apply_df = apply_df.join(self[columns], how="right")
+                apply_df = apply_df.join(self[columns], how="outer")
             else:
                 # TODO: It should be faster to pass these columns to to_lists, but its 20x slower
                 # columns = [col[1] for col in requested_columns if col[0] == layer]
-                apply_df = apply_df.join(self[layer].nest.to_lists(), how="right")
+                apply_df = apply_df.join(self[layer].nest.to_lists(), how="outer")
 
         # Translates the requested columns into the scalars or arrays we pass to func.
         def translate_cols(frame, layer, col):

--- a/src/nested_pandas/utils/utils.py
+++ b/src/nested_pandas/utils/utils.py
@@ -28,9 +28,12 @@ def count_nested(df, nested, by=None, join=True) -> NestedFrame:
     """
 
     if by is None:
-        # to_flat() is faster than direct apply in this case
-        counts = df[nested].nest.to_flat().groupby(level=0).apply(lambda x: len(x)).rename(f"n_{nested}")
+        field_to_len = df[nested].nest.fields[0]
+        counts = (
+            df[nested].nest.to_lists().apply(lambda x: len(x[field_to_len]), axis=1).rename(f"n_{nested}")
+        )
     else:
+        # this may be able to be sped up using tolists() as well
         counts = df[nested].apply(lambda x: x[by].value_counts())
         counts = counts.rename(columns={colname: f"n_{nested}_{colname}" for colname in counts.columns})
     if join:

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -242,7 +242,17 @@ def test_reduce():
 
     to_pack2 = pd.DataFrame(
         data={
-            "time": [1, 2, 3, 1, 2, 3, 1, 2, 4],
+            "time2": [
+                1,
+                2,
+                3,
+                1,
+                2,
+                3,
+                1,
+                2,
+                4,
+            ],  # TODO: fix duplicate name in join once to_list subset bug fixed
             "e": [2, 9, 4, 1, 23, 3, 1, 4, 1],
             "f": [5, 4, 7, 5, 3, 25, 9, 3, 4],
         },


### PR DESCRIPTION
This PR uses `to_lists()` in place of `to_flat()` and `apply()` for the `by=None` `count_nested` case and in `reduce` to offer a 5-10x speedup.

It does introduce one limitation to `reduce` in that the nested structures cannot have overlapping column names, this will be less of an issue once #33 is addressed. I propose we wait to resolve this overlap issue until after #33 and just make a separate issue for now. 
