### PR TITLE
Fix ndf.add_nested() for empty frames

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -99,7 +99,9 @@ class NestedFrame(pd.DataFrame):
         # Add sources to objects
         packed = packer.pack(obj, name=name, dtype=dtype)
         label = packed.name
-        return self.assign(**{f"{label}": packed})
+        new_df = self.copy()
+        new_df[label] = packed
+        return new_df
 
     def _split_query(self, expr) -> dict:
         """Splits a pandas query into multiple subqueries for nested and base layers"""

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 from nested_pandas import NestedFrame
 from pandas.testing import assert_frame_equal
@@ -128,6 +129,19 @@ def test_add_nested_with_series_and_mismatched_index():
 
     assert "nested" in base.columns
     assert pd.isna(base.loc[1]["nested"])
+
+
+def test_add_nested_for_empty_df():
+    """Test that .add_nested() works for empty frame and empty input"""
+    base = NestedFrame(data={"a": [], "b": []}, index=[])
+    nested = pd.DataFrame(data={"c": []}, index=[])
+    new_base = base.add_nested(nested, "nested")
+
+    # Check original frame is unchanged
+    assert_frame_equal(base, NestedFrame(data={"a": [], "b": []}, index=[]))
+
+    assert "nested" in new_base.columns
+    assert_frame_equal(new_base.nested.nest.to_flat(), nested.astype(pd.ArrowDtype(pa.float64())))
 
 
 def test_query():


### PR DESCRIPTION
Fixes #88.

This changes the implementation of `NestedFrame.add_nested` to use `df[name] = data` instead of `df.assign(name=data)`, because the least doesn't work for empty frames. The reason we care is `dask` metadata