### PR TITLE
Test PR: Remove numpy dependency, let Pandas introduce it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
     "pandas>=2.2,<2.3",
     "pyarrow>=15",


### PR DESCRIPTION
Pandas has a numpy dependency. Try letting Pandas handle it's installation. This still fails as Pandas does not pin to <2.0
