### PR TITLE
Add "how" argument to add_nested

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -66,7 +66,12 @@ class NestedFrame(pd.DataFrame):
         return colname in self.columns or self._is_known_hierarchical_column(colname)
 
     def add_nested(
-        self, obj, name: str, *, how: str = "left", dtype: NestedDtype | pd.ArrowDtype | pa.DataType | None = None
+        self,
+        obj,
+        name: str,
+        *,
+        how: str = "left",
+        dtype: NestedDtype | pd.ArrowDtype | pa.DataType | None = None,
     ) -> Self:  # type: ignore[name-defined] # noqa: F821
         """Packs input object to a nested column and adds it to the NestedFrame
 
@@ -90,11 +95,11 @@ class NestedFrame(pd.DataFrame):
             How to handle the operation of the two objects:
 
             - left: use calling frame's index.
-            - right: use the calling frame's index and order but drop values 
+            - right: use the calling frame's index and order but drop values
               not in the other frame's index.
             - outer: form union of calling frame's index with other frame's
               index, and sort it lexicographically.
-            - inner: form intersection of calling frame's index with other 
+            - inner: form intersection of calling frame's index with other
               frame's index, preserving the order of the calling index.
         dtype : dtype or None
             NestedDtype to use for the nested column; pd.ArrowDtype or

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -66,7 +66,7 @@ class NestedFrame(pd.DataFrame):
         return colname in self.columns or self._is_known_hierarchical_column(colname)
 
     def add_nested(
-        self, obj, name: str, *, dtype: NestedDtype | pd.ArrowDtype | pa.DataType | None = None
+        self, obj, name: str, *, how: str = "left", dtype: NestedDtype | pd.ArrowDtype | pa.DataType | None = None
     ) -> Self:  # type: ignore[name-defined] # noqa: F821
         """Packs input object to a nested column and adds it to the NestedFrame
 
@@ -86,6 +86,16 @@ class NestedFrame(pd.DataFrame):
             missing values.
         name : str
             The name of the nested column to be added to the NestedFrame.
+        how : {'left', 'right', 'outer', 'inner'}, default: 'left'
+            How to handle the operation of the two objects:
+
+            - left: use calling frame's index.
+            - right: use the calling frame's index and order but drop values 
+              not in the other frame's index.
+            - outer: form union of calling frame's index with other frame's
+              index, and sort it lexicographically.
+            - inner: form intersection of calling frame's index with other 
+              frame's index, preserving the order of the calling index.
         dtype : dtype or None
             NestedDtype to use for the nested column; pd.ArrowDtype or
             pa.DataType can also be used to specify the nested dtype. If None,
@@ -98,10 +108,8 @@ class NestedFrame(pd.DataFrame):
         """
         # Add sources to objects
         packed = packer.pack(obj, name=name, dtype=dtype)
-        label = packed.name
         new_df = self.copy()
-        new_df[label] = packed
-        return new_df
+        return new_df.join(packed, how=how)
 
     @classmethod
     def from_flat(cls, df, base_columns, nested_columns=None, index=None, name="nested"):

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -89,7 +89,8 @@ def test_add_nested_with_flat_df_and_mismatched_index():
 
     nested = pd.DataFrame(
         data={"c": [0, 2, 4, 1, 4, 3, 1, 4, 1], "d": [5, 4, 7, 5, 3, 1, 9, 3, 4]},
-        index=[0, 0, 0, 1, 1, 1, 1, 4, 4],  # no data for base index value of "2" and introduces new index value "4"
+        # no data for base index value of "2" and introduces new index value "4"
+        index=[0, 0, 0, 1, 1, 1, 1, 4, 4],
     )
 
     # Add the nested frame in a "left" fashion, where the index of the "left"
@@ -103,7 +104,7 @@ def test_add_nested_with_flat_df_and_mismatched_index():
         # Check that the nested column is aligned correctly to the base layer
         if idx in nested.index:
             assert left_res.loc[idx]["nested"] is not None
-        else: # idx only in base.index
+        else:  # idx only in base.index
             assert left_res.loc[idx]["nested"] is None
 
     # Test that the default behavior is the same as how="left" by comparing the pandas dataframes
@@ -116,8 +117,8 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     assert len(right_res) == 3
     # Check that the index of the nested layer is being used. Note that separate
     # from a traditional join this will not be the same as our nested layer index
-    # and is just dropping values from the base layer that don't have a match in 
-    # the nested layer.  
+    # and is just dropping values from the base layer that don't have a match in
+    # the nested layer.
     assert (right_res.index == nested.index.unique()).all()
     assert "nested" in right_res.columns
     # For each index check that the base layer is aligned correctly to the nested layer
@@ -142,7 +143,7 @@ def test_add_nested_with_flat_df_and_mismatched_index():
         # Check that the nested column is aligned correctly to the base layer
         if idx in nested.index:
             assert outer_res.loc[idx]["nested"] is not None
-        else: # idx only in base.index
+        else:  # idx only in base.index
             assert outer_res.loc[idx]["nested"] is None
         # Check the values for each column in our "base" layer
         for col in base.columns:
@@ -164,7 +165,6 @@ def test_add_nested_with_flat_df_and_mismatched_index():
         for col in base.columns:
             assert col in inner_res.columns
             assert not pd.isna(inner_res.loc[idx][col])
-            
 
 
 def test_add_nested_with_series():

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -96,7 +96,6 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     # Add the nested frame in a "left" fashion, where the index of the "left"
     # frame (our base layer) is preserved
     left_res = base.add_nested(nested, "nested", how="left")
-
     assert "nested" in left_res.columns
     # Check that the index of the base layer is being used
     assert (left_res.index == base.index).all()
@@ -114,13 +113,12 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     # Test adding the nested frame in a "right" fashion, where the index of the "right"
     # frame (our nested layer) is preserved
     right_res = base.add_nested(nested, "nested", how="right")
-    assert len(right_res) == 3
+    assert "nested" in right_res.columns
     # Check that the index of the nested layer is being used. Note that separate
     # from a traditional join this will not be the same as our nested layer index
     # and is just dropping values from the base layer that don't have a match in
     # the nested layer.
     assert (right_res.index == nested.index.unique()).all()
-    assert "nested" in right_res.columns
     # For each index check that the base layer is aligned correctly to the nested layer
     for idx in right_res.index:
         # Check that the nested column is aligned correctly to the base layer. Here
@@ -137,6 +135,7 @@ def test_add_nested_with_flat_df_and_mismatched_index():
 
     # Test the "outer" behavior
     outer_res = base.add_nested(nested, "nested", how="outer")
+    assert "nested" in outer_res.columns
     # We expect the new index to be the union of the base and nested indices
     assert set(outer_res.index) == set(base.index).union(set(nested.index))
     for idx in outer_res.index:
@@ -156,6 +155,7 @@ def test_add_nested_with_flat_df_and_mismatched_index():
 
     # Test the "inner" behavior
     inner_res = base.add_nested(nested, "nested", how="inner")
+    assert "nested" in inner_res.columns
     # We expect the new index to be the set intersection of the base and nested indices
     assert set(inner_res.index) == set(base.index).intersection(set(nested.index))
     for idx in inner_res.index:

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -160,7 +160,7 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     assert set(inner_res.index) == set(base.index).intersection(set(nested.index))
     for idx in inner_res.index:
         # None of our nested values should be None
-        inner_res.loc[idx]["nested"] is not None
+        assert inner_res.loc[idx]["nested"] is not None
         # Check the values for each column in our "base" layer
         for col in base.columns:
             assert col in inner_res.columns


### PR DESCRIPTION
## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
Adds a `how` argument in `add_nested` to align with a traditional pandas join and in preparation from the change from `add_nested` to `join_nested` (see https://github.com/lincc-frameworks/nested-pandas/issues/120) 

- [ ] My PR includes a link to the issue that I am addressing

## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
The previous `add_nested` implementation packed the nested frame into a single column which is then assigned to our base layer. Here we simply add this column using a traditional join and then make use of the join's `how` argument. Since our previous implementation produces the same results as the "left" argument, I was concerned that replacing the single column assignment with a join might decrease performance. However a preliminary benchmarking shows no notable change. 

<img width="801" alt="Screenshot 2024-07-25 at 1 17 40 PM" src="https://github.com/user-attachments/assets/8a8ff964-75a6-4a57-b740-e0f5c2d62de7">
 
Also of note here is that for the case of `how="right"`, the nature of the packer still means that the result is implicitly using the index of our base layer but now drops values from it that were not present in the index of our "right" nested layer.    

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
