### PR TITLE
fix for empty query results

### DIFF
--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -223,8 +223,8 @@ class NestSeriesAccessor(Mapping):
             The filtered series.
         """
         flat = self.to_flat().query(query)
-        if len(flat) == 0:
-            return pd.Series([], dtype=self._series.dtype)
+        #if len(flat) == 0:
+        #    return pd.Series([], dtype=self._series.dtype)
         return pack_sorted_df_into_struct(flat)
 
     def get_flat_index(self) -> pd.Index:

--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -223,8 +223,11 @@ class NestSeriesAccessor(Mapping):
             The filtered series.
         """
         flat = self.to_flat().query(query)
-        #if len(flat) == 0:
-        #    return pd.Series([], dtype=self._series.dtype)
+
+        if len(flat) == 0:
+            return pd.Series(
+                [], dtype=self._series.dtype, index=pd.Index([], dtype=flat.index.dtype, name=flat.index.name)
+            )
         return pack_sorted_df_into_struct(flat)
 
     def get_flat_index(self) -> pd.Index:

--- a/tests/nested_pandas/series/test_accessor.py
+++ b/tests/nested_pandas/series/test_accessor.py
@@ -1,3 +1,4 @@
+import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -485,6 +486,17 @@ def test_query_flat_empty_rows():
     desired = pd.Series([], dtype=series.dtype)
 
     assert_series_equal(filtered, desired)
+
+
+def test_query_flat_with_empty_result():
+    """Make sure the index is properly set for empty result cases"""
+    base = npd.NestedFrame({"a": []}, index=pd.Index([], dtype=np.float64))
+    nested = npd.NestedFrame({"b": []}, index=pd.Index([], dtype=np.float64))
+
+    ndf = base.add_nested(nested, "nested")
+
+    res = ndf.nested.nest.query_flat("b > 2")
+    assert res.index.dtype == np.float64
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
Resolves #129.
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
This PR addresses an issue flagged in #129. Where queries that return empty results in at least one partition on the nested-dask side can result in an error. This issue is not reproducible within Nested-Pandas, as it's a result of Dask's sensitivity to metadata and dtyping. The issue being that the empty series we produce from an empty query did not specify an index with identical name and dtype (the dtype being the important piece). This PR makes the small tweak of propagating the correctly dtype'd index.


## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
