### PR TITLE
better support '.' character in names outside of nested context

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -82,14 +82,6 @@ class NestedFrame(pd.DataFrame):
                 nested = item.split(".")[0]
                 col = ".".join(item.split(".")[1:])
                 return self[nested].nest.get_flat_series(col)
-
-        # If a nested column name is passed, return a flat series for that column
-        # flat series is chosen over list series for utility
-        # e.g. native ability to do something like ndf["nested.a"] + 3
-        # elif isinstance(item, str) and self._is_known_hierarchical_column(item):
-        #    nested, col = item.split(".")
-        #    return self[nested].nest.get_flat_series(col)
-        # Otherwise, do __getitem__ as normal
         else:
             return super().__getitem__(item)
 

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -38,7 +38,7 @@ class NestedFrame(pd.DataFrame):
         """returns a dictionary of columns for each base/nested dataframe"""
         all_columns = {"base": self.columns}
         for column in self.columns:
-            if isinstance(self[column].dtype, NestedDtype):
+            if isinstance(self.dtypes[column], NestedDtype):
                 nest_cols = self[column].nest.fields
                 all_columns[column] = nest_cols
         return all_columns
@@ -48,16 +48,18 @@ class NestedFrame(pd.DataFrame):
         """retrieves the base column names for all nested dataframes"""
         nest_cols = []
         for column in self.columns:
-            if isinstance(self[column].dtype, NestedDtype):
+            if isinstance(self.dtypes[column], NestedDtype):
                 nest_cols.append(column)
         return nest_cols
 
     def _is_known_hierarchical_column(self, colname) -> bool:
         """Determine whether a string is a known hierarchical column name"""
         if "." in colname:
-            left, right = colname.split(".")
-            if left in self.nested_columns:
-                return right in self.all_columns[left]
+            base_name = colname.split(".")[0]
+            if base_name in self.nested_columns:
+                # TODO: only handles one level of nesting for now
+                nested_name = ".".join(colname.split(".")[1:])
+                return nested_name in self.all_columns[base_name]
             return False
         return False
 
@@ -68,12 +70,25 @@ class NestedFrame(pd.DataFrame):
     def __getitem__(self, item):
         """Adds custom __getitem__ behavior for nested columns"""
 
+        if isinstance(item, str):
+            # Pre-empt the nested check if the item is a base column
+            if item in self.columns:
+                return super().__getitem__(item)
+            # If a nested column name is passed, return a flat series for that column
+            # flat series is chosen over list series for utility
+            # e.g. native ability to do something like ndf["nested.a"] + 3
+            elif self._is_known_hierarchical_column(item):
+                # TODO: only handles one level of nesting for now
+                nested = item.split(".")[0]
+                col = ".".join(item.split(".")[1:])
+                return self[nested].nest.get_flat_series(col)
+
         # If a nested column name is passed, return a flat series for that column
         # flat series is chosen over list series for utility
         # e.g. native ability to do something like ndf["nested.a"] + 3
-        if isinstance(item, str) and self._is_known_hierarchical_column(item):
-            nested, col = item.split(".")
-            return self[nested].nest.get_flat_series(col)
+        # elif isinstance(item, str) and self._is_known_hierarchical_column(item):
+        #    nested, col = item.split(".")
+        #    return self[nested].nest.get_flat_series(col)
         # Otherwise, do __getitem__ as normal
         else:
             return super().__getitem__(item)

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -136,6 +136,17 @@ def test_set_new_nested_col():
     )
 
 
+def test_get_dot_names():
+    """Test the ability to still work with column names with '.' characters outside of nesting"""
+    nf = NestedFrame.from_flat(
+        NestedFrame({"a": [1, 2, 3, 4], ".b.": [1, 1, 3, 3], "R.A.": [3, None, 6, 5]}, index=[1, 1, 2, 2]),
+        base_columns=[".b."],
+    )
+
+    assert len(nf[".b."]) == 2
+    assert len(nf["nested.R.A."]) == 4
+
+
 def test_add_nested_with_flat_df():
     """Test that add_nested correctly adds a nested column to the base df"""
 


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
Potentially addresses #144 
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
This PR provides better handling of column parsing logic to allow "." characters in column names. The main changes being adding a skip to getitem that will avoid checking for hierarchical column names if the item is simply in the pandas columns, and not assuming .split(".") will return 2 items where applicable.

