### PR TITLE
Tests for using the 'on' keyword with add_nested and packing

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -271,9 +271,8 @@ class NestedFrame(pd.DataFrame):
               index, and sort it lexicographically.
             - inner: form intersection of calling frame's index with other
               frame's index, preserving the order of the calling index.
-        on : str, list of str, default: None
-            Columns in `obj` frame to use as an index to join on rather than
-            `obj`'s index.
+        on : str, default: None
+            A column in the list 
         dtype : dtype or None
             NestedDtype to use for the nested column; pd.ArrowDtype or
             pa.DataType can also be used to specify the nested dtype. If None,
@@ -284,10 +283,13 @@ class NestedFrame(pd.DataFrame):
         NestedFrame
             A new NestedFrame with the added nested column.
         """
+        if on is not None and not isinstance(on, str):
+            raise ValueError("Currently we only support a single column for 'on'")
         # Add sources to objects
         packed = pack(obj, name=name, on=on, dtype=dtype)
         new_df = self.copy()
-        return new_df.join(packed, how=how)
+        res = new_df.join(packed, how=how, on=on)
+        return res
 
     @classmethod
     def from_flat(cls, df, base_columns, nested_columns=None, on: str | None = None, name="nested"):

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -272,7 +272,8 @@ class NestedFrame(pd.DataFrame):
             - inner: form intersection of calling frame's index with other
               frame's index, preserving the order of the calling index.
         on : str, list of str, default: None
-            Columns to join on.
+            Columns in `obj` frame to use as an index to join on rather than
+            `obj`'s index.
         dtype : dtype or None
             NestedDtype to use for the nested column; pd.ArrowDtype or
             pa.DataType can also be used to specify the nested dtype. If None,

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -10,7 +10,6 @@ import pyarrow as pa
 from pandas._libs import lib
 from pandas._typing import Any, AnyAll, Axis, IndexLabel
 from pandas.api.extensions import no_default
-from pandas.api.types import is_bool_dtype
 from pandas.core.computation.expr import PARSERS, PandasExprVisitor
 
 from nested_pandas.nestedframe.utils import extract_nest_names
@@ -522,14 +521,11 @@ class NestedFrame(pd.DataFrame):
         # to the nest and repack.  Otherwise, apply it to this instance as usual,
         # since it operated on the base attributes.
         if isinstance(result, _SeriesFromNest):
-            if not is_bool_dtype(result.dtype):
-                raise ValueError("Query condition must evaluate to a boolean Series")
-
             nest_name, flat_nest = result.nest_name, result.flat_nest
-
             # Reset index to "ordinal" like [0, 0, 0, 1, 1, 2, 2, 2]
-            flat_nest = flat_nest.set_index(self[nest_name].array.list_index)
-            query_result = result.set_axis(self[nest_name].array.list_index)
+            list_index = self[nest_name].array.get_list_index()
+            flat_nest = flat_nest.set_index(list_index)
+            query_result = result.set_axis(list_index)
             # Selecting flat values matching the query result
             new_flat_nest = flat_nest[query_result]
             new_df = self._set_filtered_flat_df(nest_name, new_flat_nest)
@@ -682,7 +678,7 @@ class NestedFrame(pd.DataFrame):
         if subset is not None:
             subset = [col.split(".")[-1] for col in subset]
         target_flat = self[target].nest.to_flat()
-        target_flat = target_flat.set_index(self[target].array.list_index)
+        target_flat = target_flat.set_index(self[target].array.get_list_index())
         if inplace:
             target_flat.dropna(
                 axis=axis,

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -652,7 +652,7 @@ class NestedExtensionArray(ExtensionArray):
         """Keys mapping values to lists"""
         if len(self) == 0:
             # Since we have no list offests, return an empty array
-            return np.empty(0)
+            return np.array([], dtype=int)
         list_index = np.arange(len(self))
         return np.repeat(list_index, np.diff(self.list_offsets))
 

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -650,6 +650,9 @@ class NestedExtensionArray(ExtensionArray):
 
     def get_list_index(self) -> np.ndarray:
         """Keys mapping values to lists"""
+        if len(self) == 0:
+            # Since we have no list offests, return an empty array
+            return np.empty(0)
         list_index = np.arange(len(self))
         return np.repeat(list_index, np.diff(self.list_offsets))
 

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -648,8 +648,7 @@ class NestedExtensionArray(ExtensionArray):
         """Number of chunks in underlying pyarrow.ChunkedArray"""
         return self._chunked_array.num_chunks
 
-    @property
-    def list_index(self) -> np.ndarray:
+    def get_list_index(self) -> np.ndarray:
         """Keys mapping values to lists"""
         list_index = np.arange(len(self))
         return np.repeat(list_index, np.diff(self.list_offsets))

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -185,32 +185,11 @@ def test_add_nested_with_flat_df():
     assert_frame_equal(base.nested.nest.to_flat(), nested, check_dtype=False)
 
 
-def test_add_nested_with_flat_df_on():
-    """Test that add_nested correctly adds a nested column to the base df with on argument"""
-
-    base = NestedFrame(data={"a": [1, 2, 3], "b": [2, 4, 6], }, index=[0, 1, 2])
-
-    nested = pd.DataFrame(
-        data={"new_index": [0, 0, 1, 1, 2, 2, 2, 2, 2,],
-        "c": [0, 2, 4, 1, 4, 3, 1, 4, 1], "d": [5, 4, 7, 5, 3, 1, 9, 3, 4]},
-        index=[0, 0, 0, 1, 1, 1, 2, 2, 2],
-    )
-
-    base = base.add_nested(nested, "nested", on="new_index")
-
-    assert "nested" in base.columns
-
-    # We expected that when the nested frame is packed in with 'on'='new_index' that the
-    # resulting flat frame is indexed by the new_index values.
-    expected_flat = nested.set_index("new_index")
-    expected_flat.index.name = None # The index name is not preserved in the flat frame
-
-    assert_frame_equal(base.nested.nest.to_flat(), expected_flat, check_dtype=False)
-
 def test_add_nested_with_flat_df_and_mismatched_index():
     """Test add_nested when index values of base are missing matches in nested"""
 
-    base = NestedFrame(data={"a": [1, 2, 3], "b": [2, 4, 6]}, index=[0, 1, 2])
+    base = NestedFrame(
+        data={"a": [1, 2, 3], "b": [2, 4, 6], "new_index": [0, 1, 3] }, index=[0, 1, 2])
 
     nested = pd.DataFrame(
         data={
@@ -241,21 +220,33 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     assert_frame_equal(left_res, default_res)
 
     # Test still adding the nested frame in a "left" fashion but on the "new_index" column
+
+    # We currently don't support a list of columns for the 'on' argument
+    with pytest.raises(ValueError):
+        left_res_on = base.add_nested(nested, "nested", how="left", on=["new_index"])
+    # Instead we should pass a single column name, "new_index" which exists in both frames.
     left_res_on = base.add_nested(nested, "nested", how="left", on="new_index")
     assert "nested" in left_res_on.columns
     # Check that the index of the base layer is still being used
     assert (left_res_on.index == base.index).all()
     # Assert that the new_index column we joined on was dropped from the nested layer
+    # but is present in the base layer
+    assert "new_index" in left_res_on.columns
     assert "new_index" not in left_res_on["nested"].nest.to_flat().columns
-    for idx in left_res_on.index:
+
+    # For each index in the columns we joined on, check that values are aligned correctly
+    for i in range(len(left_res_on.new_index)):
+        # The actual "index" value we "joined" on.
+        join_idx = left_res_on.new_index.iloc[i]
         # Check that the nested column is aligned correctly to the base layer
-        if idx in nested["new_index"].values:
-            assert left_res_on.loc[idx]["nested"] is not None
+        if join_idx in nested["new_index"].values:
+            assert left_res_on.iloc[i]["nested"] is not None
             # Check that it is present in new the index we constructed for the nested layer
-            assert idx in left_res_on["nested"].nest.to_flat().index
+            assert join_idx in left_res_on["nested"].nest.to_flat().index
         else:
-            assert left_res_on.loc[idx]["nested"] is None
-            assert idx not in left_res_on["nested"].nest.to_flat().index
+            # Use an iloc
+            assert left_res_on.iloc[i]["nested"] is None
+            assert join_idx not in left_res_on["nested"].nest.to_flat().index
 
     # Test adding the nested frame in a "right" fashion, where the index of the "right"
     # frame (our nested layer) is preserved
@@ -283,11 +274,9 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     # Test still adding the nested frame in a "right" fashion but on the "new_index" column
     right_res_on = base.add_nested(nested, "nested", how="right", on="new_index")
     assert "nested" in right_res_on.columns
-    # Check that the index of the nested layer is being used. Note that separate
-    # from a traditional join this will not be the same as our nested layer index
-    # and is just dropping values from the base layer that don't have a match in
-    # the nested layer.
-    assert (right_res_on.index.values == np.unique(nested.new_index.values)).all()
+    # Check that rows were dropped if the base layer's "new_index" value is not present
+    # in the "right" nested layer
+    assert (right_res_on.new_index.values == np.unique(nested.new_index.values)).all()
 
     # Check that the new_index column we joined on was dropped from the nested layer
     assert "new_index" not in right_res_on["nested"].nest.to_flat().columns
@@ -295,20 +284,21 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     all(right_res_on.nested.nest.to_flat().index.values == nested.new_index.values)
 
     # For each index check that the base layer is aligned correctly to the nested layer
-    for idx in right_res_on.index:
-        # Check that the nested column is aligned correctly to the base layer. Here
-        # it should never be None
-        assert right_res_on.loc[idx]["nested"] is not None
+    for i in range(len(right_res_on)):
+        # The actual "index" value we "joined" on. Since it was a right join, guaranteed to
+        # be in the "new_index" column of the orignal frame we wanted to nest
+        join_idx = right_res_on.new_index.iloc[i]
+        assert join_idx in nested["new_index"].values
+
         # Check the values for each column in our "base" layer
         for col in base.columns:
-            assert col in right_res_on.columns
-            if idx not in base.index:
-                assert idx in nested["new_index"].values
-                # We expect a NaN value in the base layer due to the "right" join
-                assert pd.isna(right_res_on.loc[idx][col])
-            else:
-                # We expect a NaN value in the base layer due to the "right" join
-                assert not pd.isna(right_res_on.loc[idx][col])
+            if col != "new_index":
+                assert col in right_res_on.columns
+                if join_idx not in base.new_index.values:
+                    # We expect a NaN value in the base layer due to the "right" join
+                    assert pd.isna(right_res_on.iloc[i][col])
+                else:
+                    assert not pd.isna(right_res_on.iloc[i][col])
 
     # Test the "outer" behavior
     outer_res = base.add_nested(nested, "nested", how="outer")
@@ -333,32 +323,34 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     # Test still adding the nested frame in an "outer" fashion but with on the "new_index" column
     outer_res_on = base.add_nested(nested, "nested", how="outer", on="new_index")
     assert "nested" in outer_res_on.columns
-    # We expect the new index to be the union of the base and nested column we used
-    # for the 'on' argument
-    assert set(outer_res_on.index) == set(base.index).union(set(nested.new_index))
+    # We expect the result's new_index column to be the set union of the values of that column
+    # in the base and nested frames
+    assert set(outer_res_on.new_index) == set(base.new_index).union(set(nested.new_index))
 
     # Check that the new_index column we joined on was dropped from the nested layer
-    assert "new_index" not in right_res_on["nested"].nest.to_flat().columns
+    assert "new_index" not in outer_res_on["nested"].nest.to_flat().columns
     # Check that the flattend nested layer has the same index as the original column we joined on
     # Note that it does not have index values only present in the base layer since those empty rows
     # are dropped when we flatten the nested frame.
-    all(right_res_on.nested.nest.to_flat().index.values == nested.new_index.values)
+    all(outer_res_on.nested.nest.to_flat().index.values == nested.new_index.values)
 
-    for idx in outer_res_on.index:
+    for i in range(len(outer_res_on)):
+        # The actual "index" value we "joined" on.
+        join_idx = outer_res_on.new_index.iloc[i]
         # Check that the nested column is aligned correctly to the base layer
-        if idx in nested["new_index"].values:
-            assert outer_res_on.loc[idx]["nested"] is not None
+        if join_idx not in nested["new_index"].values:
+            assert outer_res_on.iloc[i]["nested"] is None
         else:
-            assert outer_res_on.loc[idx]["nested"] is None
+            assert outer_res_on.iloc[i]["nested"] is not None
         # Check the values for each column in our "base" layer
         for col in base.columns:
-            assert col in outer_res_on.columns
-            if idx not in base.index:
-                assert idx in nested["new_index"].values
-                # We expect a NaN value in the base layer due to the "outer" join
-                assert pd.isna(outer_res_on.loc[idx][col])
-            else:
-                assert not pd.isna(outer_res_on.loc[idx][col])
+            if col != "new_index":
+                assert col in outer_res_on.columns
+                if join_idx in base.new_index.values:
+                    # We expect a NaN value in the base layer due to the "outer" join
+                    assert not pd.isna(outer_res_on.iloc[i][col])
+                else:
+                    assert pd.isna(outer_res_on.iloc[i][col])
 
     # Test the "inner" behavior
     inner_res = base.add_nested(nested, "nested", how="inner")
@@ -378,17 +370,13 @@ def test_add_nested_with_flat_df_and_mismatched_index():
     assert "nested" in inner_res_on.columns
     # We expect the new index to be the set intersection of the base and nested column we used
     # for the 'on' argument
-    assert set(inner_res_on.index) == set(base.index).intersection(set(nested.new_index))
+    assert set(inner_res_on.new_index) == set(base.new_index).intersection(set(nested.new_index))
     # Check that the new_index column we joined on was dropped from the nested layer
     assert "new_index" not in right_res_on["nested"].nest.to_flat().columns
-    for idx in inner_res_on.index:
-        # None of our nested values should be None
-        assert inner_res_on.loc[idx]["nested"] is not None
-        assert idx in nested["new_index"].values
-        # Check the values for each column in our "base" layer
-        for col in base.columns:
-            assert col in inner_res_on.columns
-            assert not pd.isna(inner_res_on.loc[idx][col])
+
+    # Since we have confirmed that the "nex_index" column was the intersection that we expected
+    # we know that none of the joined values should be none
+    assert not inner_res_on.isnull().values.any()
 
 def test_add_nested_with_series():
     """Test that add_nested correctly adds a nested column to the base df"""

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -542,7 +542,7 @@ def test_from_lists():
 def test_query():
     """Test that NestedFrame.query handles nested queries correctly"""
 
-    base = NestedFrame(data={"a": [1, 2, 3], "b": [2, 4, 6]}, index=[0, 1, 2])
+    base = NestedFrame(data={"a": [1, 2, 2, 3], "b": [2, 3, 4, 6]}, index=[0, 1, 1, 2])
 
     nested = pd.DataFrame(
         data={"c": [0, 2, 4, 1, 4, 3, 1, 4, 1], "d": [5, 4, 7, 5, 3, 1, 9, 3, 4]},
@@ -564,10 +564,10 @@ def test_query():
 
     # Test nested queries
     nest_queried = base.query("nested.c > 1")
-    assert len(nest_queried.nested.nest.to_flat()) == 5
+    assert len(nest_queried.nested.nest.to_flat()) == 7
 
     nest_queried = base.query("(nested.c > 1) and (nested.d>2)")
-    assert len(nest_queried.nested.nest.to_flat()) == 4
+    assert len(nest_queried.nested.nest.to_flat()) == 5
 
     # Check edge conditions
     with pytest.raises(ValueError):

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -2,10 +2,11 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from nested_pandas import NestedDtype
-from nested_pandas.series import packer
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
+
+from nested_pandas import NestedDtype
+from nested_pandas.series import packer
 
 
 def offsets_reused(nested_series):
@@ -66,6 +67,63 @@ def test_pack_with_flat_df_and_index():
     offsets_reused(series)
     assert_series_equal(series, desired)
 
+def test_pack_with_flat_df_and_on():
+    """Test packing a dataframe on a column"""
+    df = pd.DataFrame(
+        data={
+            "a": [1, 2, 3, 4],
+            "b": [0, 1, 0, 1],
+            "c": [1, 0, 1, 0],
+        },
+        index=[1, 2, 1, 2],
+    )
+    series = packer.pack(df, name="series", on="c")
+
+    desired = pd.Series(
+        data=[
+            # All of the values where the column c is 0
+            (np.array([2, 4]), np.array([1, 1])),
+            # All of the values where the column c is 1
+            (np.array([1, 3]), np.array([0, 0])),
+        ],
+        # Since we packed on 'c', we expect to see the unique sorted
+        # values of 'c' as the index
+        index=[0, 1],
+        dtype=NestedDtype.from_fields(dict(a=pa.int64(), b=pa.int64())),
+        name="series",
+    )
+    # The index name should be the same as the column we packed on
+    desired.index.name = "c"
+    offsets_reused(series)
+    assert_series_equal(series, desired)
+
+def test_pack_with_flat_df_and_on_and_index():
+    """Test packing a dataframe on a column while also specifying an index"""
+    df = pd.DataFrame(
+        data={
+            "a": [1, 2, 3, 4],
+            "b": [0, 1, 0, 1],
+            "c": [1, 0, 1, 0],
+        },
+        index=[1, 2, 1, 2],
+    )
+    new_index = [101, 102]
+    series = packer.pack(df, name="series", index=new_index, on="c")
+
+    desired = pd.Series(
+        data=[
+            # All of the values where the column c is 0
+            (np.array([2, 4]), np.array([1, 1])),
+            # All of the values where the column c is 1
+            (np.array([1, 3]), np.array([0, 0])),
+        ],
+        # We still expect to see the overriden index despite packing on 'c'
+        index=new_index,
+        dtype=NestedDtype.from_fields(dict(a=pa.int64(), b=pa.int64())),
+        name="series",
+    )
+    offsets_reused(series)
+    assert_series_equal(series, desired)
 
 def test_pack_with_series_of_dfs():
     """Test pack(pd.Series([pd.DataFrame(), ...]))."""
@@ -126,6 +184,38 @@ def test_pack_flat():
     offsets_reused(actual)
     assert_series_equal(actual, desired)
 
+def test_pack_flat_with_on():
+    """Test pack_flat() where you pack on a given column."""
+    df = pd.DataFrame(
+        data={
+            "a": [7, 8, 9, 1, 2, 3, 4, 5, 6],
+            "b": [0, 1, 0, 0, 1, 0, 1, 0, 1],
+            "c": [1, 0, 1, 0, 1, 0, 1, 0, 1],
+        },
+        index=[4, 4, 4, 1, 1, 2, 2, 3, 3],
+    )
+    # Pack on the c olumn
+    actual = packer.pack_flat(df, on="c")
+
+    desired = pd.Series(
+        data=[
+            # Index 0: # All of the values where column 'c' is 0
+            (
+                np.array([8, 1, 3, 5]),  # values from column 'a'
+                np.array([1, 0, 0, 0])   # values from column 'b'
+            ),
+            # Index 1: # All of the values where column 'c' is 1
+            (
+                np.array([7, 9, 2, 4, 6]),  # values from column 'a'
+                np.array([0, 0, 1, 1, 1])   # values from column 'b'
+            )
+        ],
+        index=[0, 1],
+        dtype=NestedDtype.from_fields(dict(a=pa.int64(), b=pa.int64())),
+    )
+    desired.index.name = "c"
+    offsets_reused(actual)
+    assert_series_equal(actual, desired)
 
 def test_pack_sorted_df_into_struct():
     """Test pack_sorted_df_into_struct()."""


### PR DESCRIPTION
Adds unit tests using the 'on' keyword in `NestedFrame.add_nested` and packer methods. Based off of the branch `non-uniq-idx`

We also modify the unit test for `NestedFrame.query` to be performed on a `NestedFrame` with a non-unique index and a simple unit test for the new `get_list_index` method.

It also incorporates minor fixes from @gitosaurus in merged in https://github.com/lincc-frameworks/nested-pandas/pull/171 