### PR TITLE
Trick extension array formatting

### DIFF
--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -893,7 +893,7 @@ def test__formatter_boxed():
     )._formatter(boxed=True)
     d = {"a": [1, 2, 3], "b": [-4.0, -5.0, -6.0]}
     df = pd.DataFrame(d)
-    assert formatter(df) == str(d)
+    assert formatter(df) == "[{a: 1, b: -4.0}; …] (3 rows)"
 
 
 def test__formetter_boxed_na():


### PR DESCRIPTION
This PR fixes #50 with a temporal hack. We should open a pandas issue and work with pandas maintainers to contribute a proper solution to this problem.

Examples of formatting with this PR
```python
>>> from nested_pandas.datasets import generate_data

>>> generate_data(3, 1)
          a         b                                        nested
0  0.263827  0.453190   [{t: 5.850555, flux: 84.944634, band: 'g'}]
1  0.561989  0.788521   [{t: 16.96538, flux: 81.045302, band: 'g'}]
2  0.752709  1.946682  [{t: 11.489896, flux: 52.094699, band: 'r'}]

>>> generate_data(3, 3)
          a         b                                             nested
0  0.037709  1.962112  [{t: 16.999902, flux: 65.742084, band: 'g'}; …...
1  0.278047  1.636276  [{t: 0.81424, flux: 11.695323, band: 'g'}; …] ...
2  0.460416  0.109109  [{t: 13.668602, flux: 15.618081, band: 'r'}; …...

>>> nf = generate_data(3, 3)
>>> nf.nested.nest['t'] = nf.nested.nest['t'].round(1)
>>> nf.nested.nest['flux'] = nf.nested.nest['flux'].round(1)
>>> nf
          a         b                                          nested
0  0.789335  0.542048   [{t: 5.8, flux: 92.2, band: 'g'}; …] (3 rows)
1  0.631588  0.953179  [{t: 13.6, flux: 59.3, band: 'r'}; …] (3 rows)
2  0.215239  0.840790   [{t: 7.6, flux: 25.3, band: 'g'}; …] (3 rows)
```