### PR TITLE
Fix NestedExtensionArray.flat_length

### DIFF
--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -241,7 +241,7 @@ class NestedExtensionArray(ExtensionArray):
                 return type(self)(self._chunked_array.filter(pa_item), validate=False)
             # It should be covered by check_array_indexer above
             raise IndexError(
-                "Only integers, slices and integer or " "boolean arrays are valid indices."
+                "Only integers, slices and integer or boolean arrays are valid indices."
             )  # pragma: no cover
 
         if isinstance(item, tuple):
@@ -764,7 +764,9 @@ class NestedExtensionArray(ExtensionArray):
     @property
     def flat_length(self) -> int:
         """Length of the flat arrays"""
-        return sum(chunk.field(0).value_lengths().sum().as_py() for chunk in self._chunked_array.iterchunks())
+        return sum(
+            chunk.field(0).value_lengths().sum().as_py() or 0 for chunk in self._chunked_array.iterchunks()
+        )
 
     @property
     def num_chunks(self) -> int:

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -1240,6 +1240,21 @@ def test_flat_length():
     assert ext_array.flat_length == 7
 
 
+def test_flat_length_empty_chunk():
+    """Test that the flat length works correctly for an empty chunk."""
+    struct_array = pa.StructArray.from_arrays(
+        arrays=[
+            pa.array([np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0, 1.0, 2.0])]),
+            pa.array([-np.array([4.0, 5.0, 6.0]), -np.array([3.0, 4.0, 5.0, 6.0])]),
+        ],
+        names=["a", "b"],
+    )
+    empty_struct_array = pa.array([], type=struct_array.type)
+    ext_array = NestedExtensionArray(pa.chunked_array([struct_array, empty_struct_array]))
+
+    assert ext_array.flat_length == 7
+
+
 def test_num_chunks():
     """Tests .num_chunks property."""
     struct_array = pa.StructArray.from_arrays(


### PR DESCRIPTION
This failed for empty chunks, because `chunk.field(0).value_lengths().sum().as_py()` returned `None`