### PR TITLE
Allow embedding base column with value repetition via assignment

### DIFF
--- a/docs/tutorials/data_manipulation.ipynb
+++ b/docs/tutorials/data_manipulation.ipynb
@@ -17,7 +17,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:41.890895Z",
+     "start_time": "2025-03-05T23:08:41.872743Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import nested_pandas as npd\n",
@@ -31,7 +36,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:41.907431Z",
+     "start_time": "2025-03-05T23:08:41.902080Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Show one of the nested dataframes\n",
@@ -55,7 +65,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:41.933782Z",
+     "start_time": "2025-03-05T23:08:41.930296Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Directly Nested Column Selection\n",
@@ -72,7 +87,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:41.956770Z",
+     "start_time": "2025-03-05T23:08:41.953485Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ndf[\"nested.t\"] + 100"
@@ -102,7 +122,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:41.992618Z",
+     "start_time": "2025-03-05T23:08:41.987910Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# prepend lsst_ to the band column\n",
@@ -122,7 +147,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:42.016312Z",
+     "start_time": "2025-03-05T23:08:42.012009Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# create a new \"corrected_t\" column in \"nested\"\n",
@@ -135,7 +165,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:42.037065Z",
+     "start_time": "2025-03-05T23:08:42.032519Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Show the first dataframe again\n",
@@ -159,7 +194,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:42.075674Z",
+     "start_time": "2025-03-05T23:08:42.061111Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ndf[\"bands.band_label\"] = ndf[\"nested.band\"]\n",
@@ -176,10 +216,66 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:42.132918Z",
+     "start_time": "2025-03-05T23:08:42.114796Z"
+    }
+   },
    "outputs": [],
    "source": [
     "ndf.add_nested(ndf[\"nested.band\"].to_frame(), \"bands_from_add_nested\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embedding \"base\" column into nested column"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also assign some \"base\" (non-nested) column to a nested column, which will be broadcasted to all nested dataframes with the values being repeated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:42.165933Z",
+     "start_time": "2025-03-05T23:08:42.161684Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ndf[\"nested.a\"] = ndf[\"a\"]\n",
+    "ndf[\"nested.a\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can do some operations over the base columns first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-03-05T23:08:42.266923Z",
+     "start_time": "2025-03-05T23:08:42.262281Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ndf[\"nested.ab\"] = ndf[\"a\"] + ndf[\"b\"] * 2\n",
+    "ndf[\"nested.ab\"]"
    ]
   }
  ],

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -195,7 +195,12 @@ class NestedFrame(pd.DataFrame):
             if len(components) != 2:
                 raise ValueError(f"Only one level of nesting is supported; given {key}")
             nested, field = components
-            new_nested_series = self[nested].nest.with_flat_field(field, value)
+            # Support a special case of embedding a base column into a nested column, with values being
+            # repeated in each nested list-array.
+            if isinstance(value, pd.Series) and self.index.equals(value.index):
+                new_nested_series = self[nested].nest.with_filled_field(field, value)
+            else:
+                new_nested_series = self[nested].nest.with_flat_field(field, value)
             return super().__setitem__(nested, new_nested_series)
 
         # Adding a new nested structure from a column

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -160,7 +160,7 @@ def test_get_nested_column():
 
 
 def test_set_or_replace_nested_col():
-    """Test that __setitem__ can set or replace a column in a existing nested structure"""
+    """Test that __setitem__ can set or replace a column in an existing nested structure"""
 
     base = NestedFrame(data={"a": [1, 2, 3], "b": [2, 4, 6]}, index=[0, 1, 2])
     c = [0, 2, 4, 1, 4, 3, 1, 4, 1]
@@ -187,6 +187,17 @@ def test_set_or_replace_nested_col():
 
     assert "e" in base.nested.nest.fields
     assert np.array_equal(base["nested.d"].values.to_numpy() * 2, base["nested.e"].values.to_numpy())
+
+    # test assignment a new column with list-repeated values
+    base["nested.a"] = base["a"]
+
+    assert "a" in base.nested.nest.fields
+    assert np.array_equal(np.unique(base["a"].to_numpy()), np.unique(base["nested.a"].to_numpy()))
+
+    # rest replacement with a list-repeated column
+    base["nested.c"] = base["a"] + base["b"] - 99
+
+    assert np.array_equal(base["a"] + base["b"] - 99, np.unique(base["nested.c"].to_numpy()))
 
 
 def test_set_new_nested_col():


### PR DESCRIPTION
So now we can do this:
```python
from nested_pandas.datasets import generate_data

ndf = generate_data(5, 20)
ndf["nested.a"] = ndf.a
ndf["nested.x"] = ndf.a * ndf.b
```

But NOT this, because we check rhs to have the same index as ndf, otherwise we do assignment assuming that the value has the "flat" shape:
```python
ndf["nested.y"] = [1,2,3,4,5]  # FAILS
```

Based on PR #213