### PR TITLE
Enable Inference of Nested Structures to Reduce outputs

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -924,7 +924,7 @@ class NestedFrame(pd.DataFrame):
         results_nf = NestedFrame(results, index=self.index)
 
         if infer_nesting:
-            # find potential nested structures
+            # find potential nested structures from columns
             nested_cols = []
             for column in results_nf.columns:
                 if isinstance(column, str) and "." in column:
@@ -937,7 +937,9 @@ class NestedFrame(pd.DataFrame):
                 layer_cols = [col for col in results_nf.columns if col.startswith(f"{layer}.")]
                 rename_df = results_nf[layer_cols].rename(columns=lambda x: x.split(".", 1)[1])
                 nested_col = pack_lists(rename_df, name=layer)
-                results_nf = results_nf[[col for col in results_nf.columns if not col.startswith(f"{layer}.")]].join(nested_col)
+                results_nf = results_nf[
+                    [col for col in results_nf.columns if not col.startswith(f"{layer}.")]
+                ].join(nested_col)
 
         return results_nf
 

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -864,7 +864,7 @@ class NestedFrame(pd.DataFrame):
             columns to apply the function to.
         infer_nesting : bool, default True
             If True, the function will pack output columns into nested
-            structures based on column names adherring to a nested naming
+            structures based on column names adhering to a nested naming
             scheme. E.g. "nested.b" and "nested.c" will be packed into a column
             called "nested" with columns "b" and "c". If False, all outputs
             will be returned as base columns.

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -925,12 +925,11 @@ class NestedFrame(pd.DataFrame):
 
         if infer_nesting:
             # find potential nested structures from columns
-            nested_cols = []
-            for column in results_nf.columns:
-                if isinstance(column, str) and "." in column:
-                    layer, col = column.split(".", 1)
-                    nested_cols.append(layer)
-            nested_cols = list(np.unique(nested_cols))
+            nested_cols = list(np.unique(
+                [column.split(".", 1)[0]
+                 for column in results_nf.columns
+                 if isinstance(column, str) and "." in column]
+            ))
 
             # pack results into nested structures
             for layer in nested_cols:

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -930,7 +930,7 @@ class NestedFrame(pd.DataFrame):
                 if isinstance(column, str) and "." in column:
                     layer, col = column.split(".", 1)
                     nested_cols.append(layer)
-            nested_cols = np.unique(nested_cols)
+            nested_cols = list(np.unique(nested_cols))
 
             # pack results into nested structures
             for layer in nested_cols:

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -925,11 +925,15 @@ class NestedFrame(pd.DataFrame):
 
         if infer_nesting:
             # find potential nested structures from columns
-            nested_cols = list(np.unique(
-                [column.split(".", 1)[0]
-                 for column in results_nf.columns
-                 if isinstance(column, str) and "." in column]
-            ))
+            nested_cols = list(
+                np.unique(
+                    [
+                        column.split(".", 1)[0]
+                        for column in results_nf.columns
+                        if isinstance(column, str) and "." in column
+                    ]
+                )
+            )
 
             # pack results into nested structures
             for layer in nested_cols:

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1021,6 +1021,57 @@ def test_reduce_duplicated_cols():
         result, pd.DataFrame({"allclose": [True, True, True]}, index=pd.Index([0, 1, 2], name="idx"))
     )
 
+    def test_reduce_infer_nesting():
+        """Test that nesting inference works in reduce"""
+
+        ndf = generate_data(3,20, seed=1)
+
+        # Test simple case
+        def complex_output(flux):
+            return {"max_flux":np.max(flux), "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5])}
+        
+        result = ndf.reduce(complex_output, "nested.flux")
+        assert list(result.columns) == ["max_flux", "lc"]
+        assert list(result.lc.nest.fields) == ['flux_quantiles']
+
+        # Test multi-column nested output
+        def complex_output(flux):
+            return {"max_flux":np.max(flux),
+                    "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]), 
+                    "lc.labels":[0.1,0.2,0.3,0.4,0.5]}
+
+        result = ndf.reduce(complex_output, "nested.flux")
+        assert list(result.columns) == ["max_flux", "lc"]
+        assert list(result.lc.nest.fields) == ['flux_quantiles', "labels"]
+
+        # Test integer names
+        def complex_output(flux):
+            return np.max(flux), np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]),[0.1,0.2,0.3,0.4,0.5]
+        
+        result = ndf.reduce(complex_output, "nested.flux")
+        assert list(result.columns) == [0, 1, 2]
+
+        # Test multiple nested structure output
+        def complex_output(flux):
+            return {"max_flux":np.max(flux),
+                    "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]),
+                    "lc.labels":[0.1,0.2,0.3,0.4,0.5],
+                    "meta.colors":["green", "red", "blue"]}
+
+        result = ndf.reduce(complex_output, "nested.flux")
+        assert list(result.columns) == ["max_flux", "lc", "meta"]
+        assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
+        assert list(result.lc.meta.fields) == ["colors"]
+
+        # Test only nested structure output
+        def complex_output(flux):
+            return {"lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]),
+                    "lc.labels":[0.1,0.2,0.3,0.4,0.5]}
+
+        result = ndf.reduce(complex_output, "nested.flux")
+        assert list(result.columns) == ["lc"]
+        assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
+
 
 def test_scientific_notation():
     """

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1021,65 +1021,66 @@ def test_reduce_duplicated_cols():
         result, pd.DataFrame({"allclose": [True, True, True]}, index=pd.Index([0, 1, 2], name="idx"))
     )
 
-    def test_reduce_infer_nesting():
-        """Test that nesting inference works in reduce"""
 
-        ndf = generate_data(3, 20, seed=1)
+def test_reduce_infer_nesting():
+    """Test that nesting inference works in reduce"""
 
-        # Test simple case
-        def complex_output(flux):
-            return {
-                "max_flux": np.max(flux),
-                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
-            }
+    ndf = generate_data(3, 20, seed=1)
 
-        result = ndf.reduce(complex_output, "nested.flux")
-        assert list(result.columns) == ["max_flux", "lc"]
-        assert list(result.lc.nest.fields) == ["flux_quantiles"]
+    # Test simple case
+    def complex_output(flux):
+        return {
+            "max_flux": np.max(flux),
+            "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+        }
 
-        # Test multi-column nested output
-        def complex_output(flux):
-            return {
-                "max_flux": np.max(flux),
-                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
-                "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
-            }
+    result = ndf.reduce(complex_output, "nested.flux")
+    assert list(result.columns) == ["max_flux", "lc"]
+    assert list(result.lc.nest.fields) == ["flux_quantiles"]
 
-        result = ndf.reduce(complex_output, "nested.flux")
-        assert list(result.columns) == ["max_flux", "lc"]
-        assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
+    # Test multi-column nested output
+    def complex_output(flux):
+        return {
+            "max_flux": np.max(flux),
+            "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+            "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
+        }
 
-        # Test integer names
-        def complex_output(flux):
-            return np.max(flux), np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]), [0.1, 0.2, 0.3, 0.4, 0.5]
+    result = ndf.reduce(complex_output, "nested.flux")
+    assert list(result.columns) == ["max_flux", "lc"]
+    assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
 
-        result = ndf.reduce(complex_output, "nested.flux")
-        assert list(result.columns) == [0, 1, 2]
+    # Test integer names
+    def complex_output(flux):
+        return np.max(flux), np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]), [0.1, 0.2, 0.3, 0.4, 0.5]
 
-        # Test multiple nested structures output
-        def complex_output(flux):
-            return {
-                "max_flux": np.max(flux),
-                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
-                "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
-                "meta.colors": ["green", "red", "blue"],
-            }
+    result = ndf.reduce(complex_output, "nested.flux")
+    assert list(result.columns) == [0, 1, 2]
 
-        result = ndf.reduce(complex_output, "nested.flux")
-        assert list(result.columns) == ["max_flux", "lc", "meta"]
-        assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
-        assert list(result.lc.meta.fields) == ["colors"]
+    # Test multiple nested structures output
+    def complex_output(flux):
+        return {
+            "max_flux": np.max(flux),
+            "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+            "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "meta.colors": ["green", "red", "blue"],
+        }
 
-        # Test only nested structure output
-        def complex_output(flux):
-            return {
-                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
-                "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
-            }
+    result = ndf.reduce(complex_output, "nested.flux")
+    assert list(result.columns) == ["max_flux", "lc", "meta"]
+    assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
+    assert list(result.meta.nest.fields) == ["colors"]
 
-        result = ndf.reduce(complex_output, "nested.flux")
-        assert list(result.columns) == ["lc"]
-        assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
+    # Test only nested structure output
+    def complex_output(flux):
+        return {
+            "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+            "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
+        }
+
+    result = ndf.reduce(complex_output, "nested.flux")
+    assert list(result.columns) == ["lc"]
+    assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
 
 
 def test_scientific_notation():

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1024,39 +1024,46 @@ def test_reduce_duplicated_cols():
     def test_reduce_infer_nesting():
         """Test that nesting inference works in reduce"""
 
-        ndf = generate_data(3,20, seed=1)
+        ndf = generate_data(3, 20, seed=1)
 
         # Test simple case
         def complex_output(flux):
-            return {"max_flux":np.max(flux), "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5])}
-        
+            return {
+                "max_flux": np.max(flux),
+                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+            }
+
         result = ndf.reduce(complex_output, "nested.flux")
         assert list(result.columns) == ["max_flux", "lc"]
-        assert list(result.lc.nest.fields) == ['flux_quantiles']
+        assert list(result.lc.nest.fields) == ["flux_quantiles"]
 
         # Test multi-column nested output
         def complex_output(flux):
-            return {"max_flux":np.max(flux),
-                    "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]), 
-                    "lc.labels":[0.1,0.2,0.3,0.4,0.5]}
+            return {
+                "max_flux": np.max(flux),
+                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+                "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
+            }
 
         result = ndf.reduce(complex_output, "nested.flux")
         assert list(result.columns) == ["max_flux", "lc"]
-        assert list(result.lc.nest.fields) == ['flux_quantiles', "labels"]
+        assert list(result.lc.nest.fields) == ["flux_quantiles", "labels"]
 
         # Test integer names
         def complex_output(flux):
-            return np.max(flux), np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]),[0.1,0.2,0.3,0.4,0.5]
-        
+            return np.max(flux), np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]), [0.1, 0.2, 0.3, 0.4, 0.5]
+
         result = ndf.reduce(complex_output, "nested.flux")
         assert list(result.columns) == [0, 1, 2]
 
-        # Test multiple nested structure output
+        # Test multiple nested structures output
         def complex_output(flux):
-            return {"max_flux":np.max(flux),
-                    "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]),
-                    "lc.labels":[0.1,0.2,0.3,0.4,0.5],
-                    "meta.colors":["green", "red", "blue"]}
+            return {
+                "max_flux": np.max(flux),
+                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+                "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
+                "meta.colors": ["green", "red", "blue"],
+            }
 
         result = ndf.reduce(complex_output, "nested.flux")
         assert list(result.columns) == ["max_flux", "lc", "meta"]
@@ -1065,8 +1072,10 @@ def test_reduce_duplicated_cols():
 
         # Test only nested structure output
         def complex_output(flux):
-            return {"lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]),
-                    "lc.labels":[0.1,0.2,0.3,0.4,0.5]}
+            return {
+                "lc.flux_quantiles": np.quantile(flux, [0.1, 0.2, 0.3, 0.4, 0.5]),
+                "lc.labels": [0.1, 0.2, 0.3, 0.4, 0.5],
+            }
 
         result = ndf.reduce(complex_output, "nested.flux")
         assert list(result.columns) == ["lc"]


### PR DESCRIPTION
Resolves #132 and is related to #101.

This PR enables reduce to optionally use the resulting names of a result dataframe to create nested structures, for example a function like below will automatically create the nested columns "lc" and "meta" as detailed by the nesting column naming scheme:
```python
from nested_pandas.datasets import generate_data
import numpy as np

ndf = generate_data(3,20, seed=1)

def complex_output(flux):
    return {"max_flux":np.max(flux),
                "lc.flux_quantiles":np.quantile(flux, [0.1,0.2,0.3,0.4,0.5]), 
                "lc.labels":[0.1,0.2,0.3,0.4,0.5], 
                "meta.colors":["green", "red", "blue"]}

result = ndf.reduce(complex_output, "nested.flux")
```

I opted for the #101 interface here instead of the #132 as it seemed more natural to the overall API.