### PR TITLE
Add inner_dtypes to NestedDtype for sub-column dtype casting

### DIFF
--- a/docs/tutorials/low_level.ipynb
+++ b/docs/tutorials/low_level.ipynb
@@ -340,16 +340,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "422e719861ae40f6",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-03-05T20:34:52.352751Z",
-     "start_time": "2025-03-05T20:34:52.350143Z"
-    }
-   },
+   "id": "da7788cc04b78a2a",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "nested_series.equals(pd.Series(struct_series, dtype=NestedDtype.from_pandas_arrow_dtype(struct_series.dtype)))"
+    "nested_series.equals(pd.Series(struct_series, dtype=NestedDtype(struct_series.dtype)))"
    ]
   },
   {

--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -109,7 +109,7 @@ class NestSeriesAccessor(Mapping):
                 index=pd.Series(index, name=self._series.index.name),
                 name=field,
                 copy=False,
-                dtype=pd.ArrowDtype(chunked_array.type),
+                dtype=self._series.dtype.inner_dtype(field),
             )
 
         return pd.DataFrame(flat_series)
@@ -292,7 +292,7 @@ class NestSeriesAccessor(Mapping):
 
         return pd.Series(
             flat_chunked_array,
-            dtype=pd.ArrowDtype(flat_chunked_array.type),
+            dtype=self._series.dtype.inner_dtype(field),
             index=self.get_flat_index(),
             name=field,
             copy=False,

--- a/src/nested_pandas/series/dtype.py
+++ b/src/nested_pandas/series/dtype.py
@@ -20,7 +20,14 @@ __all__ = ["NestedDtype"]
 
 @register_extension_dtype
 class NestedDtype(ExtensionDtype):
-    """Data type to handle packed time series data"""
+    """Data type to handle packed time series data
+
+    Parameters
+    ----------
+    pyarrow_dtype : pyarrow.StructType or pd.ArrowDtype
+        The pyarrow data type to use for the nested type. It must be a struct
+        type where all fields are list types.
+    """
 
     # ExtensionDtype overrides #
 
@@ -135,7 +142,9 @@ class NestedDtype(ExtensionDtype):
 
     pyarrow_dtype: pa.StructType
 
-    def __init__(self, pyarrow_dtype: pa.DataType) -> None:
+    def __init__(self, pyarrow_dtype: pa.DataType | pd.ArrowDtype) -> None:
+        if isinstance(pyarrow_dtype, pd.ArrowDtype):
+            pyarrow_dtype = pyarrow_dtype.pyarrow_dtype
         self.pyarrow_dtype = self._validate_dtype(pyarrow_dtype)
 
     @classmethod
@@ -192,27 +201,6 @@ class NestedDtype(ExtensionDtype):
     def field_names(self) -> list[str]:
         """The list of field names of the nested type"""
         return [field.name for field in self.pyarrow_dtype]
-
-    @classmethod
-    def from_pandas_arrow_dtype(cls, pandas_arrow_dtype: ArrowDtype):
-        """Construct NestedDtype from a pandas.ArrowDtype.
-
-        Parameters
-        ----------
-        pandas_arrow_dtype : ArrowDtype
-            The pandas.ArrowDtype to construct NestedDtype from.
-
-        Returns
-        -------
-        NestedDtype
-            The constructed NestedDtype.
-
-        Raises
-        ------
-        ValueError
-            If the given dtype is not a valid nested type.
-        """
-        return cls(pyarrow_dtype=pandas_arrow_dtype.pyarrow_dtype)
 
     def to_pandas_arrow_dtype(self) -> ArrowDtype:
         """Convert NestedDtype to a pandas.ArrowDtype.

--- a/src/nested_pandas/series/dtype.py
+++ b/src/nested_pandas/series/dtype.py
@@ -173,7 +173,7 @@ class NestedDtype(ExtensionDtype):
         self.inner_dtypes = self._validate_inner_dtypes(self.pyarrow_dtype, inner_dtypes)
 
     @classmethod
-    def from_fields(cls, fields: Mapping[str, pa.DataType | Self]) -> Self:  # type: ignore[name-defined] # noqa: F821
+    def from_fields(cls, fields: Mapping[str, pa.DataType | pa.ArrowDtype | Self]) -> Self:  # type: ignore[name-defined] # noqa: F821
         """Make NestedDtype from a mapping of field names and list item types.
 
         Parameters
@@ -204,6 +204,8 @@ class NestedDtype(ExtensionDtype):
             if isinstance(dtype, NestedDtype):
                 inner_dtypes[field] = dtype
                 dtype = dtype.pyarrow_dtype
+            elif isinstance(dtype, pd.ArrowDtype):
+                dtype = dtype.pyarrow_dtype
             pa_fields[field] = dtype
         pyarrow_dtype = pa.struct({field: pa.list_(pa_type) for field, pa_type in pa_fields.items()})
         return cls(pyarrow_dtype=pyarrow_dtype, inner_dtypes=inner_dtypes or None)
@@ -229,7 +231,7 @@ class NestedDtype(ExtensionDtype):
         pyarrow_dtype: pa.StructType, inner_dtypes: Mapping[str, object] | None
     ) -> dict[str, object]:
         # Short circuit if there are no inner dtypes
-        if inner_dtypes is None:
+        if inner_dtypes is None or len(inner_dtypes) == 0:
             return {}
 
         inner_dtypes = dict(inner_dtypes)

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -245,11 +245,11 @@ class NestedExtensionArray(ExtensionArray):
         del copy
 
         pa_type = to_pyarrow_dtype(dtype)
-        pa_array, infered_inner_dtypes = cls._box_pa_array(scalars, pa_type=pa_type)
+        pa_array, inferred_inner_dtypes = cls._box_pa_array(scalars, pa_type=pa_type)
         if isinstance(dtype, NestedDtype):
             inner_dtypes = dtype.inner_dtypes
-        elif len(infered_inner_dtypes) > 1:
-            inner_dtypes = infered_inner_dtypes
+        elif len(inferred_inner_dtypes) > 1:
+            inner_dtypes = inferred_inner_dtypes
         else:
             inner_dtypes = None
         return cls(pa_array, inner_dtypes=inner_dtypes)

--- a/tests/nested_pandas/series/test_dtype.py
+++ b/tests/nested_pandas/series/test_dtype.py
@@ -20,8 +20,9 @@ from nested_pandas.series.ext_array import NestedExtensionArray
 )
 def test_from_pyarrow_dtype(pyarrow_dtype):
     """Test that we can construct NestedDtype from pyarrow struct type."""
-    dtype = NestedDtype(pyarrow_dtype)
-    assert dtype.pyarrow_dtype == pyarrow_dtype
+    dtype1 = NestedDtype(pyarrow_dtype)
+    dtype2 = NestedDtype(pd.ArrowDtype(pyarrow_dtype))
+    assert dtype1.pyarrow_dtype == dtype2.pyarrow_dtype == pyarrow_dtype
 
 
 @pytest.mark.parametrize(
@@ -39,6 +40,8 @@ def test_from_pyarrow_dtype_raises(pyarrow_dtype):
     """Test that we raise an error when constructing NestedDtype from invalid pyarrow type."""
     with pytest.raises(ValueError):
         NestedDtype(pyarrow_dtype)
+    with pytest.raises(ValueError):
+        NestedDtype(pd.ArrowDtype(pyarrow_dtype))
 
 
 def test_to_pandas_arrow_dtype():

--- a/tests/nested_pandas/series/test_dtype.py
+++ b/tests/nested_pandas/series/test_dtype.py
@@ -54,7 +54,7 @@ def test_to_pandas_arrow_dtype():
 
 def test_from_fields():
     """Test NestedDtype.from_fields()."""
-    fields1 = {"a": pa.int64(), "b": pa.float64()}
+    fields1 = {"a": pa.int64(), "b": pd.ArrowDtype(pa.float64())}
     dtype1 = NestedDtype.from_fields(fields1)
     assert dtype1.pyarrow_dtype == pa.struct(
         [pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))]

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from nested_pandas import NestedDtype
+from nested_pandas.datasets import generate_data
 from nested_pandas.series import packer
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -219,6 +220,19 @@ def test_pack_flat_with_on():
     desired.index.name = "c"
     offsets_reused(actual)
     assert_series_equal(actual, desired)
+
+
+def test_pack_flat_with_nested():
+    """Test pack_flat when input already has nested columns."""
+    df = generate_data(10, 3)
+    index = [0, 0, 1, 1, 2, 2, 2, 2, 0, 0]
+    df.index = index
+    actual = packer.pack_flat(df)
+
+    desired_dtype = NestedDtype.from_fields(
+        {col: t if isinstance(t, NestedDtype) else pa.from_numpy_dtype(t) for col, t in df.dtypes.items()}
+    )
+    assert actual.dtype == desired_dtype, f"{actual.dtype.name} != {desired_dtype.name}"
 
 
 def test_pack_sorted_df_into_struct():


### PR DESCRIPTION
It is the first step for multiple nesting implementation. 

This is a draft PR, because I found the implementation to be over-complicated. Probably the better solution is using list-struct as the default data representation instead of this `inner_dtypes` system.