### PR TITLE
Performance Improvement for Serialization

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -133,23 +133,7 @@ def read_parquet(
         indices_to_remove = []
         for col, indices in nested_structures.items():
             # Build a struct column from the columns
-            field_names = [table.column_names[i] for i in indices]
-
-            # Use iterchunks to process chunks of each column
-            chunked_arrays = []
-            for i in indices:
-                column = table.column(i)
-                if len(column.chunks) == 1:
-                    # If there is only one chunk, use it directly
-                    # avoid copy in concat_arrays
-                    chunked_arrays.append(column.chunk(0))
-                else:
-                    # Otherwise, concatenate all chunks
-                    chunked_arrays.append(pa.concat_arrays(list(column.iterchunks())))
-            structs[col] = pa.StructArray.from_arrays(
-                chunked_arrays,  # Child arrays
-                field_names,  # Field names
-            )
+            structs[col] = table.select(indices).to_struct_array()
             indices_to_remove.extend(indices)
 
         # Remove the original columns in reverse order to avoid index shifting


### PR DESCRIPTION
Avoids concatenation in favor of just doing pyarrows struct array conversion from table selections.

With this, testing on my end (which is limited to a single dummy test file) indicates that there's very little if any additional memory pressure from the nested-pandas end compared to pandas and pyarrow both in full loads and partial loads. I also noticed that while pyarrow's max memory usage of partially loading a struct does not seem any smaller than a full load, so while I was surprised to not see any benefit on the nested side it looks like that is pyarrow

Here's my reproducer experiment:

```
from nested_pandas.datasets.generation import generate_data
nf = generate_data(1000,1000, seed=1)
nf.to_parquet("serial_test.parquet")
```

```
from memory_profiler import memory_usage
import pyarrow.parquet as pq

def myfunc():
  return pq.read_table("serial_test.parquet", columns=["a", "nested"]) # swap "nested" for "nested.flux"

mem = max(memory_usage(proc=myfunc))

print("Maximum memory used: {} MiB".format(mem))
```

I see very little change in the above block when swapping between partial and full loads of "nested"