### PR TITLE
Preparation for list-struct backend for NestedExtensionArray

### DIFF
--- a/docs/reference/ext_array.rst
+++ b/docs/reference/ext_array.rst
@@ -23,6 +23,7 @@ Functions
     series.ext_array.NestedExtensionArray.dropna
     series.ext_array.NestedExtensionArray.from_sequence
     series.ext_array.NestedExtensionArray.to_arrow_ext_array
+    series.ext_array.NestedExtensionArray.to_pyarrow_scalar
     series.ext_array.NestedExtensionArray.iter_field_lists
     series.ext_array.NestedExtensionArray.view_fields
     series.ext_array.NestedExtensionArray.set_flat_field

--- a/src/nested_pandas/series/dtype.py
+++ b/src/nested_pandas/series/dtype.py
@@ -20,7 +20,14 @@ __all__ = ["NestedDtype"]
 
 @register_extension_dtype
 class NestedDtype(ExtensionDtype):
-    """Data type to handle packed time series data"""
+    """Data type to handle packed time series data
+
+    Parameters
+    ----------
+    pyarrow_dtype : pyarrow.StructType or pd.ArrowDtype
+        The pyarrow data type to use for the nested type. It must be a struct
+        type where all fields are list types.
+    """
 
     # ExtensionDtype overrides #
 
@@ -38,7 +45,12 @@ class NestedDtype(ExtensionDtype):
     @property
     def name(self) -> str:
         """The string representation of the nested type"""
-        fields = ", ".join([f"{field.name}: [{field.type.value_type!s}]" for field in self.pyarrow_dtype])
+        # Replace pd.ArrowDtype with pa.DataType, because it has nicer __str__
+        nice_dtypes = {
+            field: dtype.pyarrow_dtype if isinstance(dtype, pd.ArrowDtype) else dtype
+            for field, dtype in self.fields.items()
+        }
+        fields = ", ".join([f"{field}: [{dtype!s}]" for field, dtype in nice_dtypes.items()])
         return f"nested<{fields}>"
 
     @classmethod

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -755,6 +755,23 @@ class NestedExtensionArray(ExtensionArray):
             return ArrowExtensionArray(self._list_array)
         return ArrowExtensionArray(self._chunked_array)
 
+    def to_pyarrow_scalar(self, list_struct: bool = False) -> pa.ListScalar:
+        """Convert to a pyarrow scalar of a list type
+
+        Parameters
+        ----------
+        list_struct : bool, optional
+            If False (default), return list-struct-list scalar,
+            otherwise  list-list-struct scalar.
+
+        Returns
+        -------
+        pyarrow.ListScalar
+        """
+        pa_array = self._list_array if list_struct else self._chunked_array
+        pa_type = pa.list_(pa_array.type)
+        return cast(pa.ListScalar, pa.scalar(pa_array, type=pa_type))
+
     def _replace_chunked_array(self, pa_array: pa.ChunkedArray, *, validate: bool) -> None:
         if validate:
             self._validate(pa_array)

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -785,7 +785,7 @@ class NestedExtensionArray(ExtensionArray):
         ----------
         list_struct : bool, optional
             If False (default), return list-struct-list scalar,
-            otherwise  list-list-struct scalar.
+            otherwise list-list-struct scalar.
 
         Returns
         -------

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -225,7 +225,7 @@ class NestedExtensionArray(ExtensionArray):
         pa_array = cls._box_pa_array(scalars, pa_type=pa_type)
         return cls(pa_array)
 
-    # Tricky to implement, but required by things like pd.read_csv
+    # Tricky to implement but required by things like pd.read_csv
     @classmethod
     def _from_sequence_of_strings(cls, strings, *, dtype=None, copy: bool = False) -> Self:  # type: ignore[name-defined] # noqa: F821
         return super()._from_sequence_of_strings(strings, dtype=dtype, copy=copy)
@@ -679,6 +679,29 @@ class NestedExtensionArray(ExtensionArray):
         for struct_chunk in self._chunked_array.iterchunks():
             list_chunks.append(transpose_struct_list_array(struct_chunk, validate=False))
         return pa.chunked_array(list_chunks)
+
+    @property
+    def _struct_array(self) -> pa.ChunkedArray:
+        """Pyarrow chunked struct-list array representation
+
+        Returns
+        -------
+        pa.ChunkedArray
+            Pyarrow chunked-array of struct-list arrays.
+        """
+        return self._chunked_array
+
+    @property
+    def _pa_table(self) -> pa.Table:
+        """Pyarrow table representation of the extension array.
+
+        Returns
+        -------
+        pa.Table
+            Pyarrow table where each column is a list array corresponding
+            to a field of the struct array.
+        """
+        return pa.Table.from_struct_array(self._struct_array)
 
     @classmethod
     def from_sequence(cls, scalars, *, dtype: NestedDtype | pd.ArrowDtype | pa.DataType = None) -> Self:  # type: ignore[name-defined] # noqa: F821

--- a/src/nested_pandas/series/utils.py
+++ b/src/nested_pandas/series/utils.py
@@ -157,6 +157,9 @@ def transpose_list_struct_type(t: pa.ListType) -> pa.StructType:
     if not is_pa_type_a_list(t):
         raise ValueError(f"Expected a ListType, got {t}")
 
+    if not pa.types.is_struct(t.value_type):
+        raise ValueError(f"Expected a StructType as a list value type, got {t.value_type}")
+
     struct_type = cast(pa.StructType, t.value_type)
     fields = []
     for field in struct_type:

--- a/tests/nested_pandas/series/test_dtype.py
+++ b/tests/nested_pandas/series/test_dtype.py
@@ -18,7 +18,7 @@ from nested_pandas.series.ext_array import NestedExtensionArray
         ),
     ],
 )
-def test_from_pyarrow_dtype(pyarrow_dtype):
+def test_from_pyarrow_dtype_struct_list(pyarrow_dtype):
     """Test that we can construct NestedDtype from pyarrow struct type."""
     dtype = NestedDtype(pyarrow_dtype)
     assert dtype.pyarrow_dtype == pyarrow_dtype
@@ -27,9 +27,29 @@ def test_from_pyarrow_dtype(pyarrow_dtype):
 @pytest.mark.parametrize(
     "pyarrow_dtype",
     [
+        pa.list_(pa.struct([pa.field("a", pa.int64())])),
+        pa.list_(pa.struct([pa.field("a", pa.int64()), pa.field("b", pa.float64())])),
+        pa.list_(
+            pa.struct(
+                [
+                    pa.field("a", pa.list_(pa.int64())),
+                    pa.field("b", pa.list_(pa.float64())),
+                ]
+            )
+        ),
+    ],
+)
+def test_from_pyarrow_dtype_list_struct(pyarrow_dtype):
+    """Test that we can construct NestedDtype from pyarrow list type."""
+    dtype = NestedDtype(pyarrow_dtype)
+    assert dtype.list_struct_pyarrow_dtype == pyarrow_dtype
+
+
+@pytest.mark.parametrize(
+    "pyarrow_dtype",
+    [
         pa.int64(),
         pa.list_(pa.int64()),
-        pa.list_(pa.struct([pa.field("a", pa.int64())])),
         pa.struct([pa.field("a", pa.int64())]),
         pa.struct([pa.field("a", pa.int64()), pa.field("b", pa.float64())]),
         pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.float64())]),
@@ -47,6 +67,18 @@ def test_to_pandas_arrow_dtype():
     assert dtype.to_pandas_arrow_dtype() == pd.ArrowDtype(
         pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.list_(pa.float64()))])
     )
+
+
+def test_from_pandas_arrow_dtype():
+    """Test that we can construct NestedDtype from pandas.ArrowDtype."""
+    dtype_from_struct = NestedDtype.from_pandas_arrow_dtype(
+        pd.ArrowDtype(pa.struct([pa.field("a", pa.list_(pa.int64()))]))
+    )
+    assert dtype_from_struct.pyarrow_dtype == pa.struct([pa.field("a", pa.list_(pa.int64()))])
+    dtype_from_list = NestedDtype.from_pandas_arrow_dtype(
+        pd.ArrowDtype(pa.list_(pa.struct([pa.field("a", pa.int64())])))
+    )
+    assert dtype_from_list.pyarrow_dtype == pa.struct([pa.field("a", pa.list_(pa.int64()))])
 
 
 def test_to_pandas_list_struct_arrow_dtype():

--- a/tests/nested_pandas/series/test_dtype.py
+++ b/tests/nested_pandas/series/test_dtype.py
@@ -49,6 +49,14 @@ def test_to_pandas_arrow_dtype():
     )
 
 
+def test_to_pandas_list_struct_arrow_dtype():
+    """Test that NestedDtype.to_pandas_arrow_dtype(list_struct=True) returns the correct pyarrow type."""
+    dtype = NestedDtype.from_fields({"a": pa.list_(pa.int64()), "b": pa.float64()})
+    assert dtype.to_pandas_arrow_dtype(list_struct=True) == pd.ArrowDtype(
+        pa.list_(pa.struct([pa.field("a", pa.list_(pa.int64())), pa.field("b", pa.float64())]))
+    )
+
+
 def test_from_fields():
     """Test NestedDtype.from_fields()."""
     fields = {"a": pa.int64(), "b": pa.float64()}

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -1873,6 +1873,36 @@ def test___init___with_list_struct_array():
     assert pa.array(ext_array) == struct_array
 
 
+def test__struct_array():
+    """Test ._struct_array property"""
+    struct_array = pa.StructArray.from_arrays(
+        arrays=[
+            pa.array([np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0, 1.0, 2.0])]),
+            pa.array([-np.array([4.0, 5.0, 6.0]), -np.array([3.0, 4.0, 5.0, 6.0])]),
+        ],
+        names=["a", "b"],
+    )
+    ext_array = NestedExtensionArray(struct_array)
+
+    assert ext_array._struct_array.combine_chunks() == struct_array
+
+
+def test__pa_table():
+    """Test ._pa_table property"""
+    struct_array = pa.StructArray.from_arrays(
+        arrays=[
+            pa.array([np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0, 1.0, 2.0])]),
+            pa.array([-np.array([4.0, 5.0, 6.0]), -np.array([3.0, 4.0, 5.0, 6.0])]),
+        ],
+        names=["a", "b"],
+    )
+    ext_array = NestedExtensionArray(struct_array)
+
+    assert ext_array._pa_table == pa.Table.from_arrays(
+        arrays=[struct_array.field("a"), struct_array.field("b")], names=["a", "b"]
+    )
+
+
 def test__from_sequence_of_strings():
     """We do not support from_sequence_of_strings() which would apply things like pd.read_csv()"""
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
This PR adds a couple of helper functions to prepare a transition from struct-list chunked array to list-structure chunked array as the storage of `NestedExtensionArray` data.