### PR TITLE
Run CI with lowest versions of deps

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,3 +36,26 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-lowest-versions:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        python -m pip install --upgrade uv
+        uv venv venv
+        source venv/bin/activate
+        uv pip compile --resolution=lowest -o requirements_lowest.txt pyproject.toml
+        uv pip install --constraint=requirements_lowest.txt -e '.[dev]'
+    - name: Run unit tests with pytest
+      run: |
+        source venv/bin/activate
+        python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,9 @@ requires-python = ">=3.9"
 dependencies = [
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
-    "pandas>=2.2,<2.3",
+    "pandas>=2.2.3,<2.3",
     "pyarrow>=18",
-    "universal_pathlib"
-
+    "universal_pathlib>=0.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Run CI with oldest dependencies of the package while using newest versions for [dev] dependencies. It is a prototype of https://github.com/lincc-frameworks/python-project-template/issues/495 implementation