### PR TITLE
Support kwargs and loading from directories in `read_parquet`

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -148,9 +148,7 @@ def read_parquet(
     # Convert to NestedFrame
     # not zero-copy, but reduce memory pressure via the self_destruct kwarg
     # https://arrow.apache.org/docs/python/pandas.html#reducing-memory-use-in-table-to-pandas
-    df = NestedFrame(
-        table.to_pandas(types_mapper=pd.ArrowDtype, split_blocks=True, self_destruct=True)
-    )
+    df = NestedFrame(table.to_pandas(types_mapper=pd.ArrowDtype, split_blocks=True, self_destruct=True))
     del table
     # Attempt to cast struct columns to NestedDTypes
     df = _cast_struct_cols_to_nested(df, reject_nesting)

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -36,6 +36,8 @@ def read_parquet(
         is castable to a nested column. However, this assumption is invalid if
         the lists within the struct have mismatched lengths for any given item.
         Columns specified here will be read using the corresponding pandas.ArrowDtype.
+    kwargs: dict
+        Keyword arguments passed to `pyarrow.parquet.read_table`
 
     Returns
     -------

--- a/tests/nested_pandas/e2e_tests/test_issue89.py
+++ b/tests/nested_pandas/e2e_tests/test_issue89.py
@@ -1,4 +1,5 @@
 """Based on https://github.com/lincc-frameworks/nested-pandas/issues/89"""
+from pyarrow.dataset import partitioning
 
 import nested_pandas as npd
 import numpy as np
@@ -16,11 +17,13 @@ def test_issue89():
     object_ndf = npd.read_parquet(
         f"{catalogs_dir}/ztf_object/Norder=3/Dir=0/Npix=432.parquet",
         columns=["ra", "dec", "ps1_objid"],
+        partitioning=None,
     ).set_index("ps1_objid")
 
     source_ndf = npd.read_parquet(
         f"{catalogs_dir}/ztf_source/Norder=6/Dir=20000/Npix=27711.parquet",
         columns=["mjd", "mag", "magerr", "band", "ps1_objid", "catflags"],
+        partitioning=None,
     ).set_index("ps1_objid")
 
     object_ndf = object_ndf.add_nested(source_ndf, "ztf_source")

--- a/tests/nested_pandas/e2e_tests/test_issue89.py
+++ b/tests/nested_pandas/e2e_tests/test_issue89.py
@@ -1,5 +1,4 @@
 """Based on https://github.com/lincc-frameworks/nested-pandas/issues/89"""
-from pyarrow.dataset import partitioning
 
 import nested_pandas as npd
 import numpy as np

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -5,11 +5,10 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from upath import UPath
-
 from nested_pandas import read_parquet
 from nested_pandas.datasets import generate_data
 from pandas.testing import assert_frame_equal
+from upath import UPath
 
 
 def test_read_parquet():

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from upath import UPath
+
 from nested_pandas import read_parquet
 from nested_pandas.datasets import generate_data
 from pandas.testing import assert_frame_equal
@@ -14,6 +16,39 @@ def test_read_parquet():
     """Test reading a parquet file with no columns specified"""
     # Load in the example file
     nf = read_parquet("tests/test_data/nested.parquet")
+
+    # Check the columns
+    assert nf.columns.tolist() == ["a", "flux", "nested", "lincc"]
+
+    # Make sure nested columns were recognized
+    assert nf.nested_columns == ["nested", "lincc"]
+
+    # Check the nested columns
+    assert nf.nested.nest.fields == ["t", "flux", "band"]
+    assert nf.lincc.nest.fields == ["band", "frameworks"]
+
+
+def test_read_parquet_directory():
+    """Test reading a parquet file with no columns specified"""
+    # Load in the example file
+    nf = read_parquet("tests/test_data")
+
+    # Check the columns
+    assert nf.columns.tolist() == ["a", "flux", "nested", "lincc"]
+
+    # Make sure nested columns were recognized
+    assert nf.nested_columns == ["nested", "lincc"]
+
+    # Check the nested columns
+    assert nf.nested.nest.fields == ["t", "flux", "band"]
+    assert nf.lincc.nest.fields == ["band", "frameworks"]
+
+
+def test_read_parquet_directory_with_filesystem():
+    """Test reading a parquet file with no columns specified"""
+    # Load in the example file
+    path = UPath("tests/test_data")
+    nf = read_parquet(path.path, filesystem=path.fs)
 
     # Check the columns
     assert nf.columns.tolist() == ["a", "flux", "nested", "lincc"]


### PR DESCRIPTION
Passes kwargs from `read_parquet` to `pq.read_table`. Also changes how `UPath` loading works, passing the path and filesystem to read_parquet to be able to read from a directory instead of opening the path manually.