### PR TITLE
Change NestedExtArray.__arrow__ to return list_struct

### DIFF
--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -577,10 +577,10 @@ class NestedExtensionArray(ExtensionArray):
         """Convert the extension array to a PyArrow array."""
         # struct_array is the default "external" representation
         if type is None:
-            return self.struct_array
-        if is_pa_type_a_list(type):
-            return self.list_array.cast(type)
-        return self.struct_array.cast(type)
+            return self.list_array
+        if pa.types.is_struct(type):
+            return self.struct_array.cast(type)
+        return self.list_array.cast(type)
 
     def __array__(self, dtype=None):
         """Convert the extension array to a numpy array."""

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -1063,17 +1063,13 @@ def test_dropna():
 
 def test___arrow_array__():
     """Test that the extension array can be converted to a pyarrow array."""
-    struct_array = pa.StructArray.from_arrays(
-        arrays=[
-            pa.array([np.array([1, 2, 3]), np.array([1, 2, 1])]),
-            pa.array([-np.array([4.0, 5.0, 6.0]), -np.array([3.0, 4.0, 5.0])]),
-        ],
-        names=["a", "b"],
+    list_array = pa.array(
+        [[{"a": 1, "b": 2}, {"a": 3, "b": 4}], [{"a": 5, "b": 6}], [{"a": -1, "b": -2}], []]
     )
-    ext_array = NestedExtensionArray(struct_array)
+    ext_array = NestedExtensionArray(list_array)
 
     arrow_array = pa.array(ext_array)
-    assert arrow_array == struct_array
+    assert arrow_array == list_array
 
 
 def test___arrow_array___with_type_cast():
@@ -1891,14 +1887,7 @@ def test___init___with_list_struct_array():
     ext_array = NestedExtensionArray(list_array)
     assert ext_array.field_names == ["a", "b"]
     assert ext_array.flat_length == 4
-    struct_array = pa.StructArray.from_arrays(
-        arrays=[
-            pa.array([[1, 3], [5], [-1], []]),
-            pa.array([[2, 4], [6], [-2], []]),
-        ],
-        names=["a", "b"],
-    )
-    assert pa.array(ext_array) == struct_array
+    assert pa.array(ext_array) == list_array
 
 
 def test__struct_array():


### PR DESCRIPTION
It is a small change which would allow us to implicitly track multiple-nested arrays: each field which is a list-struct array could be cast to a nested array.