### PR TITLE
Accessor to return NestedDtype flat series

### DIFF
--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -128,10 +128,10 @@ class NestSeriesAccessor(Mapping):
             chunked_array = pa.chunked_array(chunks)
             flat_series[field] = pd.Series(
                 chunked_array,
-                index=pd.Series(index, name=self._series.index.name),
+                index=index,
                 name=field,
                 copy=False,
-                dtype=pd.ArrowDtype(chunked_array.type),
+                dtype=self._series.dtype.field_dtype(field),
             )
 
         return pd.DataFrame(flat_series)
@@ -435,7 +435,7 @@ class NestSeriesAccessor(Mapping):
 
         return pd.Series(
             flat_chunked_array,
-            dtype=pd.ArrowDtype(flat_chunked_array.type),
+            dtype=self._series.dtype.field_dtype(field),
             index=self.get_flat_index(),
             name=field,
             copy=False,

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -240,6 +240,12 @@ class NestedExtensionArray(ExtensionArray):
         """
         del copy
 
+        if isinstance(dtype, NestedDtype) and isinstance(scalars, (cls, pa.Array, pa.ChunkedArray)):
+            if is_pa_type_a_list(scalars.type):
+                return cls(scalars.cast(dtype.list_struct_pa_dtype))
+            elif pa.types.is_struct(scalars.type):
+                return cls(scalars.cast(dtype.pyarrow_dtype))
+
         pa_type = to_pyarrow_dtype(dtype)
         pa_array = cls._box_pa_array(scalars, pa_type=pa_type)
         return cls(pa_array)


### PR DESCRIPTION
Adding support of inner nested fields returned by `.nest["inner_nested"]` and `.nest.to_flat()`