### PR TITLE
Add .nest.to_flatten_inner

### DIFF
--- a/docs/reference/accessor.rst
+++ b/docs/reference/accessor.rst
@@ -17,6 +17,7 @@ Functions
 
     NestSeriesAccessor.to_lists
     NestSeriesAccessor.to_flat
+    NestSeriesAccessor.to_flatten_inner
     NestSeriesAccessor.with_field
     NestSeriesAccessor.with_flat_field
     NestSeriesAccessor.with_list_field
@@ -26,4 +27,3 @@ Functions
     NestSeriesAccessor.get_flat_index
     NestSeriesAccessor.get_flat_series
     NestSeriesAccessor.get_list_series
-

--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -548,7 +548,10 @@ class NestSeriesAccessor(Mapping):
         a nested series.
 
         Each row of this Series is changed in the following way:
-        1. Each nested item in the given field is converted to a "flat" frame. If a nested item contains fields that are also nested, those are brought up as their own nested structures in the resulting "flat" frame.
+        1. Each nested item in the given field is converted to a "flat" frame.
+          If a nested item contains fields that are also nested, those are
+          brought up as their own nested structures in the resulting "flat"
+          frame.
         2. All items of other fields are repeated as many times as that frame
           length.
 

--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -548,7 +548,7 @@ class NestSeriesAccessor(Mapping):
         a nested series.
 
         Each row of this Series is changed in the following way:
-        1. Each nested item in the given field is converted to a "flat" frame.
+        1. Each nested item in the given field is converted to a "flat" frame. If a nested item contains fields that are also nested, those are brought up as their own nested structures in the resulting "flat" frame.
         2. All items of other fields are repeated as many times as that frame
           length.
 

--- a/tests/nested_pandas/series/test_accessor.py
+++ b/tests/nested_pandas/series/test_accessor.py
@@ -1100,3 +1100,10 @@ def test_to_flatten_inner():
         outer_flatten.nest.to_flat(),
         check_like=True,
     )
+
+
+def test_to_flatten_outer_wrong_field():
+    """Test an exception is raised when .nest.to_flatten_inner() called for a wrong field."""
+    nf = generate_data(10, 2)
+    with pytest.raises(ValueError):
+        nf.nested.nest.to_flatten_inner("t")

--- a/tests/nested_pandas/series/test_accessor.py
+++ b/tests/nested_pandas/series/test_accessor.py
@@ -1084,15 +1084,6 @@ def test_to_flatten_inner():
     nf = nf.rename(columns={"nested": "inner"})
     nnf = NestedFrame.from_flat(nf, base_columns=[], on="id", name="outer")
 
-    # outer = nnf["outer"]
-    # inner = outer.nest["inner"]
-    # for field, dtype in outer.dtype.field_dtypes.items():
-    #     if isinstance(dtype, NestedDtype):
-    #         continue
-    #     inner = inner.nest.with_filled_field(field, outer.nest[field])
-    #     outer = outer.nest.without_field(field)
-    #
-    # nnf = nnf.drop("outer", axis=1).add_nested(inner.nest.to_flat(), "outer_flatten")
     outer_flatten = nnf["outer"].nest.to_flatten_inner("inner")
 
     assert_frame_equal(


### PR DESCRIPTION
This adds a niche accessor method to "explode" an inner nested frame into the outer nested frame. It basically the same as nf.join(nf.nested.nest.to_flat()), but applied to each "higher" level nested row.

It should be useful for the cases when nested series was nested one more time with `NestedFrame.add_nested` and supposed to be flatten after that. It may be used as a part of ZTF DR22 cross-matching pipeline to concatenate multiple light-curves matched to a single object into a single multi-band light-curve.