### PR TITLE
Propagate inner nested columns to elements

### DIFF
--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -177,7 +177,13 @@ def replace_with_mask(array: pa.ChunkedArray, mask: pa.BooleanArray, value: pa.A
 
 
 def convert_df_to_pa_scalar(df: pd.DataFrame, *, pa_type: pa.DataType | None) -> pa.Scalar:
-    d = {column: series.values for column, series in df.to_dict("series").items()}
+    d = {}
+    for column, series in df.to_dict("series").items():
+        if isinstance(series.dtype, NestedDtype):
+            values = series.array.to_pyarrow_scalar(list_struct=True)
+        else:
+            values = series.values
+        d[column] = values
     return pa.scalar(d, type=pa_type, from_pandas=True)
 
 

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -299,6 +299,17 @@ def test_convert_df_to_pa_from_scalar():
     )
 
 
+def test_convert_df_to_pa_scalar_from_pyarrow_dtyped_df():
+    """Test that we can convert a frame with pd.ArrowDtype series to pyarrow struct_scalar."""
+    df = pd.DataFrame({"a": pd.Series([1, 2, 3], dtype=pd.ArrowDtype(pa.int32())), "b": [-4.0, -5.0, -6.0]})
+    pa_scalar = convert_df_to_pa_scalar(df, pa_type=None)
+
+    assert pa_scalar == pa.scalar(
+        {"a": [1, 2, 3], "b": [-4.0, -5.0, -6.0]},
+        type=pa.struct([pa.field("a", pa.list_(pa.int32())), pa.field("b", pa.list_(pa.float64()))]),
+    )
+
+
 def test__box_pa_array_from_series_of_df():
     """Test that we can convert a DataFrame to a pyarrow scalar."""
     series = pd.Series(

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -2,7 +2,8 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from nested_pandas import NestedDtype
+from nested_pandas import NestedDtype, NestedFrame
+from nested_pandas.datasets import generate_data
 from nested_pandas.series import packer
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -439,6 +440,17 @@ def test_pack_seq_with_series_of_dfs():
     )
     offsets_reused(series)
     assert_series_equal(series, desired)
+
+
+def test_pack_seq_with_double_nested():
+    """Test pack_seq works nice for frames with nested columns."""
+    nf = generate_data(10, 3)
+    nf["id"] = [0, 0, 1, 2, 2, 3, 4, 4, 5, 5]
+    desired = NestedFrame.from_flat(nf, base_columns=[], on="id", name="outer")["outer"].reset_index(
+        drop=True,
+    )
+    actual = packer.pack_seq(list(desired))
+    assert_frame_equal(actual.nest.to_flat(), desired.nest.to_flat())
 
 
 def test_view_sorted_df_as_list_arrays():


### PR DESCRIPTION
Use inner nested dtypes for "element" data-frames. I think we should also use `NestedFrame` for the output, but I'd like to have a benchmark for that, so I opened https://github.com/lincc-frameworks/nested-pandas/issues/270