### PR TITLE
Drop Python 3.9, bump PPT

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v2.0.6
+_commit: v2.0.7
 _src_path: gh:lincc-frameworks/python-project-template
 author_email: brantd@uw.edu
 author_name: LINCC Frameworks
@@ -18,8 +18,8 @@ project_license: MIT
 project_name: nested-pandas
 project_organization: lincc-frameworks
 python_versions:
-- '3.9'
 - '3.10'
 - '3.11'
 - '3.12'
 - '3.13'
+test_lowest_version: all

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -1,3 +1,4 @@
+
 # This workflow will install Python dependencies, run tests and report code coverage with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
@@ -15,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -36,17 +37,14 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-
   test-lowest-versions:
-    
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -54,7 +52,7 @@ jobs:
         uv venv venv
         source venv/bin/activate
         uv pip compile --resolution=lowest -o requirements_lowest.txt pyproject.toml
-        uv pip install --constraint=requirements_lowest.txt -e '.[dev]'
+        uv pip install --constraint=requirements_lowest.txt -e .[dev]
     - name: Run unit tests with pytest
       run: |
         source venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
@@ -60,18 +60,9 @@ testpaths = [
 ]
 addopts = "--doctest-modules --doctest-glob=*.rst"
 
-[tool.black]
-line-length = 110
-target-version = ["py39"]
-
-[tool.isort]
-profile = "black"
-line_length = 110
-
 [tool.ruff]
 line-length = 110
-target-version = "py39"
-
+target-version = "py310"
 [tool.ruff.lint]
 select = [
     # pycodestyle
@@ -103,7 +94,6 @@ select = [
     # Numpy v2.0 compatibility
     "NPY201",
 ]
-
 ignore = [
     "UP006", # Allow non standard library generics in type hints
     "UP007", # Allow Union in type hints
@@ -113,6 +103,7 @@ ignore = [
     "UP015", # Allow redundant open parameters
     "UP028", # Allow yield in for loop
 ]
+
 [tool.setuptools.package-data]
 nested_pandas = ["py.typed"]
 

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -538,7 +538,7 @@ class NestedFrame(pd.DataFrame):
                 # This is a simple heuristic but infers more than its dtype
                 # which will probably be an object.
                 sample_val = df[col].iloc[0]
-                if not hasattr(sample_val, "__iter__") and not isinstance(sample_val, (str, bytes)):
+                if not hasattr(sample_val, "__iter__") and not isinstance(sample_val, str | bytes):
                     raise ValueError(
                         f"Cannot pack column {col} which does not contain an iterable list based "
                         "on its first value, {sample_val}."
@@ -1290,7 +1290,7 @@ class NestedFrame(pd.DataFrame):
             else:
                 iterators.append(self[layer].array.iter_field_lists(col))
 
-        results = [func(*cols, *extra_args, **kwargs) for cols in zip(*iterators)]
+        results = [func(*cols, *extra_args, **kwargs) for cols in zip(*iterators, strict=True)]
         results_nf = NestedFrame(results, index=self.index)
 
         if infer_nesting:

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -87,7 +87,7 @@ def read_parquet(
     # First load through pyarrow
     # Check if `data` is a file-like object or a sequence
     if hasattr(data, "read") or (
-        isinstance(data, Sequence) and not isinstance(data, (str, bytes, bytearray))
+        isinstance(data, Sequence) and not isinstance(data, str | bytes | bytearray)
     ):
         # If `data` is a file-like object or a sequence, pass it directly to pyarrow
         table = pq.read_table(data, columns=columns, **kwargs)
@@ -103,7 +103,7 @@ def read_parquet(
     # was from a nested column.
     if columns is not None:
         nested_structures: dict[str, list[int]] = {}
-        for i, (col_in, col_pa) in enumerate(zip(columns, table.column_names)):
+        for i, (col_in, col_pa) in enumerate(zip(columns, table.column_names, strict=True)):
             # if the column name is not the same, it was a partial load
             if col_in != col_pa:
                 # get the top-level column name

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -35,8 +35,8 @@
 # typing.Self and "|" union syntax don't exist in Python 3.9
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable, Iterator, Sequence
-from typing import Any, Callable, cast
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -551,7 +551,7 @@ class NestedExtensionArray(ExtensionArray):
                     return series.apply(repr)
 
                 def format_row(row):
-                    return ", ".join(f"{name}: {value}" for name, value in zip(row.index, row))
+                    return ", ".join(f"{name}: {value}" for name, value in zip(row.index, row, strict=True))
 
                 # Format series to strings
                 df = df.apply(format_series, axis=0)
@@ -665,7 +665,7 @@ class NestedExtensionArray(ExtensionArray):
         """Convert a value to a PyArrow array with the specified type."""
         if isinstance(value, cls):
             pa_array = value.struct_array
-        elif isinstance(value, (pa.Array, pa.ChunkedArray)):
+        elif isinstance(value, pa.Array | pa.ChunkedArray):
             pa_array = value
         else:
             try:
@@ -700,7 +700,7 @@ class NestedExtensionArray(ExtensionArray):
             if dtype is None or dtype == arraylike.dtype:
                 return arraylike
             array = arraylike.list_array
-        elif isinstance(arraylike, (pa.Array, pa.ChunkedArray)):
+        elif isinstance(arraylike, pa.Array | pa.ChunkedArray):
             array = arraylike
         else:
             array = pa.array(arraylike)
@@ -1112,7 +1112,7 @@ class NestedExtensionArray(ExtensionArray):
             )
         if np.size(value) != len(self):
             raise ValueError("The length of the input array must be equal to the length of the series")
-        if isinstance(value, (pa.ChunkedArray, pa.Array)):
+        if isinstance(value, pa.ChunkedArray | pa.Array):
             value = pa.compute.take(value, self.get_list_index())
         else:
             value = np.repeat(value, self.list_lengths)

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -1375,9 +1375,9 @@ def test_iter_field_lists():
     )
     ext_array = NestedExtensionArray(struct_array)
 
-    for actual, desired in zip(ext_array.iter_field_lists("a"), a):
+    for actual, desired in zip(ext_array.iter_field_lists("a"), a, strict=True):
         assert_array_equal(actual, desired)
-    for actual, desired in zip(ext_array.iter_field_lists("b"), b):
+    for actual, desired in zip(ext_array.iter_field_lists("b"), b, strict=True):
         assert_array_equal(actual, desired)
 
 


### PR DESCRIPTION
Updates PPT to 2.0.7 and drops Python 3.9 support. The reason is that there is no 3.9 binary wheels for pandas 2.3, while building from source takes a while in the CI (see #279).

I also implemented the Ruff suggestions, however the `zip(strict=False)` thing looks a bit silly