### PR TITLE
Add `from_pyarrow` method to load nested frame from pyarrow table

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -97,74 +97,7 @@ def read_parquet(
         filesystem = kwargs.pop("filesystem", path.fs)
         table = pq.read_table(path.path, columns=columns, filesystem=filesystem, **kwargs)
 
-    return from_pyarrow(table, columns=columns, reject_nesting=reject_nesting)
-
-
-def from_pyarrow(
-    table: pa.Table,
-    columns: list[str] | None = None,
-    reject_nesting: list[str] | str | None = None,
-) -> NestedFrame:
-    """
-    Load a parquet object from a file path into a NestedFrame.
-
-    As a deviation from `pandas`, this function loads via
-    `pyarrow.parquet.read_table`, and then converts to a NestedFrame.
-
-    Parameters
-    ----------
-    data: str, Upath, or file-like object
-        Path to the data or a file-like object. If a string is passed, it can be a single file name,
-        directory name, or a remote path (e.g., HTTP/HTTPS or S3). If a file-like object is passed,
-        it must support the `read` method.
-    columns : list, default=None
-        If not None, only these columns will be read from the file.
-    reject_nesting: list or str, default=None
-        Column(s) to reject from being cast to a nested dtype. By default,
-        nested-pandas assumes that any struct column with all fields being lists
-        is castable to a nested column. However, this assumption is invalid if
-        the lists within the struct have mismatched lengths for any given item.
-        Columns specified here will be read using the corresponding pandas.ArrowDtype.
-    kwargs: dict
-        Keyword arguments passed to `pyarrow.parquet.read_table`
-
-    Returns
-    -------
-    NestedFrame
-
-    Notes
-    -----
-    pyarrow supports partial loading of nested structures from parquet, for
-    example ```pd.read_parquet("data.parquet", columns=["nested.a"])``` will
-    load the "a" column of the "nested" column. Standard pandas/pyarrow
-    behavior will return "a" as a list-array base column with name "a". In
-    nested-pandas, this behavior is changed to load the column as a sub-column
-    of a nested column called "nested". Be aware that this will prohibit calls
-    like ```pd.read_parquet("data.parquet", columns=["nested.a", "nested"])```
-    from working, as this implies both full and partial load of "nested".
-
-    Furthermore, there are some cases where subcolumns will have the same name
-    as a top-level column. For example, if you have a column "nested" with
-    subcolumns "nested.a" and "nested.b", and also a top-level column "a". In
-    these cases, keep in mind that if "nested" is in the reject_nesting list
-    the operation will fail, as is consistent with the default pandas behavior
-    (but nesting will still work normally).
-
-    Examples
-    --------
-
-    Simple loading example:
-
-    >>> import nested_pandas as npd
-    >>> nf = npd.read_parquet("path/to/file.parquet")  # doctest: +SKIP
-
-    Partial loading:
-
-    >>> #Load only the "flux" sub-column of the "nested" column
-    >>> nf = npd.read_parquet("path/to/file.parquet", columns=["a", "nested.flux"])  # doctest: +SKIP
-    """
-
-    # Type convergence for reject_nesting
+        # Type convergence for reject_nesting
     if reject_nesting is None:
         reject_nesting = []
     elif isinstance(reject_nesting, str):
@@ -224,6 +157,38 @@ def from_pyarrow(
         # Append the new struct columns
         for col, struct in structs.items():
             table = table.append_column(col, struct)
+
+    return from_pyarrow(table, reject_nesting=reject_nesting)
+
+
+def from_pyarrow(
+    table: pa.Table,
+    reject_nesting: list[str] | str | None = None,
+) -> NestedFrame:
+    """
+    Load a pyarrow Table object into a NestedFrame.
+
+    Parameters
+    ----------
+    table: pa.Table
+        PyArrow Table object to load NestedFrame from
+    reject_nesting: list or str, default=None
+        Column(s) to reject from being cast to a nested dtype. By default,
+        nested-pandas assumes that any struct column with all fields being lists
+        is castable to a nested column. However, this assumption is invalid if
+        the lists within the struct have mismatched lengths for any given item.
+        Columns specified here will be read using the corresponding pandas.ArrowDtype.
+
+    Returns
+    -------
+    NestedFrame
+
+    """
+
+    if reject_nesting is None:
+        reject_nesting = []
+    elif isinstance(reject_nesting, str):
+        reject_nesting = [reject_nesting]
 
     # Convert to NestedFrame
     # not zero-copy, but reduce memory pressure via the self_destruct kwarg

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -194,7 +194,6 @@ def from_pyarrow(
     # not zero-copy, but reduce memory pressure via the self_destruct kwarg
     # https://arrow.apache.org/docs/python/pandas.html#reducing-memory-use-in-table-to-pandas
     df = NestedFrame(table.to_pandas(types_mapper=pd.ArrowDtype, split_blocks=True, self_destruct=True))
-    del table
     # Attempt to cast struct columns to NestedDTypes
     df = _cast_struct_cols_to_nested(df, reject_nesting)
 

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -5,10 +5,12 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from nested_pandas import read_parquet
-from nested_pandas.datasets import generate_data
 from pandas.testing import assert_frame_equal
 from upath import UPath
+
+from nested_pandas import read_parquet
+from nested_pandas.datasets import generate_data
+from nested_pandas.nestedframe.io import from_pyarrow
 
 
 def test_read_parquet():
@@ -219,6 +221,42 @@ def test_read_parquet_test_mixed_struct():
         )
         assert nf.columns.tolist() == ["id", "list3", "val1"]
         assert len(nf.nested_columns) == 0
+
+
+def test_from_pyarrow_test_mixed_struct():
+    """Test reading a pyarrow table with mixed struct types"""
+    # Create the pure-list StructArray
+    field1 = pa.array([[1, 2], [3, 4], [5, 6]])
+    field2 = pa.array([["a", "b"], ["b", "c"], ["c", "d"]])
+    field3 = pa.array([[True, False], [True, False], [True, False]])
+    struct_array_list = pa.StructArray.from_arrays([field1, field2, field3], ["list1", "list2", "list3"])
+
+    # Create the value StructArray
+    field1 = pa.array([1, 2, 3])
+    field2 = pa.array(["a", "b", "c"])
+    field3 = pa.array([True, False, True])
+    struct_array_val = pa.StructArray.from_arrays([field1, field2, field3], ["val1", "va12", "val3"])
+
+    # Create the mixed-list StructArray
+    field1 = pa.array([1, 2, 3])
+    field2 = pa.array(["a", "b", "c"])
+    field3 = pa.array([[True, False], [True, False], [True, False]])
+    struct_array_mix = pa.StructArray.from_arrays([field1, field2, field3], ["val1", "va12", "list3"])
+
+    # Create a PyArrow Table with the StructArray as one of the columns
+    table = pa.table(
+        {
+            "id": pa.array([100, 101, 102]),  # Another column
+            "struct_list": struct_array_list,  # Struct column
+            "struct_value": struct_array_val,
+            "struct_mix": struct_array_mix,
+        }
+    )
+
+    # Test full read
+    nf = from_pyarrow(table)
+    assert nf.columns.tolist() == ["id", "struct_list", "struct_value", "struct_mix"]
+    assert nf.nested_columns == ["struct_list"]
 
 
 def test_to_parquet():


### PR DESCRIPTION
Refactors the `read_parquet` method to allow for loading a nested frame from a pyarrow table.