### PR TITLE
Improve html repr

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -12,6 +12,7 @@ from pandas._typing import Any, AnyAll, Axis, IndexLabel
 from pandas.api.extensions import no_default
 from pandas.core.computation.eval import Expr, ensure_scope
 from pandas.core.dtypes.inference import is_list_like
+from pandas.api.types import is_float_dtype
 
 from nested_pandas.nestedframe.expr import (
     _identify_aliases,
@@ -118,7 +119,8 @@ class NestedFrame(pd.DataFrame):
                 return None
             # Grab length, then truncate to one row for display
             n_rows = len(chunk)
-            chunk = chunk.head(1).astype({col: "str" for col in chunk.columns})  # only show the first row
+            chunk = chunk.head(1).round(8)
+            chunk.astype({col: "str" for col in chunk.columns})  # only show the first row
 
             # Add a row that shows the number of additional rows not shown
             len_row = pd.DataFrame(

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -118,14 +118,21 @@ class NestedFrame(pd.DataFrame):
                 return None
             # Grab length, then truncate to one row for display
             n_rows = len(chunk)
-            chunk = chunk.head(1).astype({col: "str" for col in chunk.columns})  # only show the first row          
+            chunk = chunk.head(1).astype({col: "str" for col in chunk.columns})  # only show the first row
 
             # Add a row that shows the number of additional rows not shown
-            len_row = pd.DataFrame({col: [f"<i>+{n_rows-1} rows</i>"] if i == 0 else ["..."] for i, col in enumerate(chunk.columns)})
+            len_row = pd.DataFrame(
+                {
+                    col: [f"<i>+{n_rows-1} rows</i>"] if i == 0 else ["..."]
+                    for i, col in enumerate(chunk.columns)
+                }
+            )
             chunk = pd.concat([chunk, len_row], ignore_index=True)
 
             # Estimate width and resize
-            html_res = chunk.to_html(max_rows=2, max_cols=5, show_dimensions=False, index=False, header=header, escape=False)
+            html_res = chunk.to_html(
+                max_rows=2, max_cols=5, show_dimensions=False, index=False, header=header, escape=False
+            )
             return html_res
 
         # Handle sizing, trim html dataframe if output will be truncated

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -12,7 +12,6 @@ from pandas._typing import Any, AnyAll, Axis, IndexLabel
 from pandas.api.extensions import no_default
 from pandas.core.computation.eval import Expr, ensure_scope
 from pandas.core.dtypes.inference import is_list_like
-from pandas.api.types import is_float_dtype
 
 from nested_pandas.nestedframe.expr import (
     _identify_aliases,
@@ -119,8 +118,8 @@ class NestedFrame(pd.DataFrame):
                 return None
             # Grab length, then truncate to one row for display
             n_rows = len(chunk)
-            chunk = chunk.head(1).round(8)
-            chunk.astype({col: "str" for col in chunk.columns})  # only show the first row
+            chunk = chunk.head(1).round(8)  # only show first row
+            chunk.astype({col: "str" for col in chunk.columns})  # cast to string for info row
 
             # Add a row that shows the number of additional rows not shown
             len_row = pd.DataFrame(


### PR DESCRIPTION
Iterates on the existing html repr in two ways:
* Better alignment of all nested dataframes for a given column, by reintroducing the header for each nestedframe, note that it's still not perfect.
* Compensate for the added height of the header by doing away with the "n rows x m columns" string, and instead packing "+n rows" directly within the dataframe.

Ultimately this is subjective, but I think this repr conveys more clearly that these are their own dataframes, and the "+n rows" feels more effective at conveying that these are truncated views.


<img width="747" alt="Screenshot 2025-06-12 at 1 42 05 PM" src="https://github.com/user-attachments/assets/5830c5bd-7c6d-4d29-9894-d4742532aed6" />
