### PR TITLE
Fix a failure for nest["field"] and empty chunks

### DIFF
--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -125,9 +125,7 @@ class NestSeriesAccessor(Mapping):
         flat_series = {}
         for field, chunks in flat_chunks.items():
             dtype = self._series.dtype.field_dtype(field)
-            if len(chunks) == 0:
-                chunks = [pa.array([])]
-            chunked_array = pa.chunked_array(chunks)
+            chunked_array = pa.chunked_array(chunks, type=self._series.dtype.fields[field])
             flat_series[field] = pd.Series(
                 chunked_array,
                 index=index,
@@ -433,7 +431,7 @@ class NestSeriesAccessor(Mapping):
             flat_array = list_array.flatten()
             flat_chunks.append(flat_array)
 
-        flat_chunked_array = pa.chunked_array(flat_chunks)
+        flat_chunked_array = pa.chunked_array(flat_chunks, type=self._series.dtype.fields[field])
 
         return pd.Series(
             flat_chunked_array,


### PR DESCRIPTION
This morning I was running a pipeline with LSDB and got an exception:

```
File ~/rubin-user/linccf/.venv/lib/python3.12/site-packages/nested_pandas/series/accessor.py:436, in NestSeriesAccessor.get_flat_series(self, field)
    433     flat_array = list_array.flatten()
    434     flat_chunks.append(flat_array)
--> [436](https://vscode-remote+ssh-002dremote-002bslac-002diana.vscode-resource.vscode-cdn.net/sdf/home/k/kostya/rubin-user/linccf/internal/object_search/~/rubin-user/linccf/.venv/lib/python3.12/site-packages/nested_pandas/series/accessor.py:436) flat_chunked_array = pa.chunked_array(flat_chunks)
    438 return pd.Series(
    439     flat_chunked_array,
    440     dtype=self._series.dtype.field_dtype(field),
   (...)    443     copy=False,
```

I don't really know how to reproduce it, but this PR should fix it. I also changed a similar code in another place for consistency.