### PR TITLE
Add append_columns= to NestedFrame.reduce

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -1184,7 +1184,7 @@ class NestedFrame(pd.DataFrame):
                 return None
             return new_df
 
-    def reduce(self, func, *args, infer_nesting=True, **kwargs) -> NestedFrame:  # type: ignore[override]
+    def reduce(self, func, *args, infer_nesting=True, append_columns=False, **kwargs) -> NestedFrame:  # type: ignore[override]
         """
         Takes a function and applies it to each top-level row of the NestedFrame.
 
@@ -1208,6 +1208,8 @@ class NestedFrame(pd.DataFrame):
             scheme. E.g. "nested.b" and "nested.c" will be packed into a column
             called "nested" with columns "b" and "c". If False, all outputs
             will be returned as base columns.
+        append_columns : bool, default False
+            if True, the output columns should be appended to those in the original NestedFrame.
         kwargs : keyword arguments, optional
             Keyword arguments to pass to the function.
 
@@ -1334,6 +1336,11 @@ class NestedFrame(pd.DataFrame):
                     [col for col in results_nf.columns if not col.startswith(f"{layer}.")]
                 ].join(nested_col)
 
+        if append_columns:
+            # Append the results to the original NestedFrame
+            return self.join(results_nf)
+
+        # Otherwise, return the results as a new NestedFrame
         return results_nf
 
     def to_pandas(self, list_struct=False) -> pd.DataFrame:

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1092,8 +1092,8 @@ def test_reduce():
     result_c = list(result.columns)
     nf_c = list(nf.columns)
     # The result should have the original columns plus the new max columns
-    assert result_c[:len(nf_c)] == nf_c
-    assert result_c[len(nf_c):] == ["max_col1", "max_col2"]
+    assert result_c[: len(nf_c)] == nf_c
+    assert result_c[len(nf_c) :] == ["max_col1", "max_col2"]
     assert result.index.name == "idx"
     for i in range(len(result)):
         assert result["max_col1"].values[i] == expected_max_c[i]

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1085,6 +1085,23 @@ def test_reduce():
     result = nf.reduce(make_id, "b", prefix_str="some_id_")
     assert result[0][1] == "some_id_4"
 
+    # Verify that append_columns=True works as expected
+    result = nf.reduce(get_max, "packed.c", "packed.d", append_columns=True)
+    assert len(result) == len(nf)
+    assert isinstance(result, NestedFrame)
+    result_c = list(result.columns)
+    nf_c = list(nf.columns)
+    # The result should have the original columns plus the new max columns
+    assert result_c[:len(nf_c)] == nf_c
+    assert result_c[len(nf_c):] == ["max_col1", "max_col2"]
+    assert result.index.name == "idx"
+    for i in range(len(result)):
+        assert result["max_col1"].values[i] == expected_max_c[i]
+        assert result["max_col2"].values[i] == expected_max_d[i]
+        # The original columns should still be present
+        assert result["packed.c"].values[i] == to_pack["c"].values[i]
+        assert result["packed.d"].values[i] == to_pack["d"].values[i]
+
 
 def test_reduce_duplicated_cols():
     """Tests nf.reduce() to correctly handle duplicated column names."""


### PR DESCRIPTION
## Change Description

NestedFrame.reduce takes an append_columns= argument that functions the same way as lsdb.catalog.Catalog.reduce, performing the needed NestedFrame.join.  The purpose is to reduce confusion as people move code fragments between `Catalog` and `NestedFrame`.

Closes #298 .

## Solution Description

Test for the argument name and perform a simple `self.join()` on the results to be returned.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

### New Feature Checklist
- [X] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [X] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
