### PR TITLE
Correctly handle non-unique index in reduce()

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -1337,7 +1337,7 @@ class NestedFrame(pd.DataFrame):
 
         if append_columns:
             # Append the results to the original NestedFrame
-            return self.join(results_nf)
+            return pd.concat([self, results_nf], axis=1)
 
         # Otherwise, return the results as a new NestedFrame
         return results_nf

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1090,7 +1090,10 @@ def test_reduce():
     result = nf.reduce(make_id, "b", prefix_str="some_id_")
     assert result[0][1] == "some_id_4"
 
-    # Verify that append_columns=True works as expected
+    # Verify that append_columns=True works as expected.
+    # Ensure that even with non-unique indexes, the final result retains
+    # the original index (nested-pandas#301)
+    nf.index = pd.Index([0, 1, 1], name="non-unique")
     result = nf.reduce(get_max, "packed.c", "packed.d", append_columns=True)
     assert len(result) == len(nf)
     assert isinstance(result, NestedFrame)
@@ -1099,7 +1102,8 @@ def test_reduce():
     # The result should have the original columns plus the new max columns
     assert result_c[: len(nf_c)] == nf_c
     assert result_c[len(nf_c) :] == ["max_col1", "max_col2"]
-    assert result.index.name == "idx"
+    assert result.index.name == "non-unique"
+    assert list(result.index) == [0, 1, 1]
     for i in range(len(result)):
         assert result["max_col1"].values[i] == expected_max_c[i]
         assert result["max_col2"].values[i] == expected_max_d[i]


### PR DESCRIPTION
## Change Description

Implementation of `NestedFrame.reduce` used join, rather than `pd.concat`, which incorrectly inflates the number of rows when an index contains non-unique values.

Updated the test to exercise this case, and fixed the implementation to pass the test.

Closes #301 .

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
