### PR TITLE
Lower pyarrow requirement from 18 to 17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
     "pandas>=2.2.3,<2.4",
-    "pyarrow>=18",
+    "pyarrow>=17",
     "universal_pathlib>=0.2",
 ]
 

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -59,6 +59,7 @@ from nested_pandas.series.utils import (
     chunk_lengths,
     is_pa_type_a_list,
     rechunk,
+    struct_field_names,
     transpose_struct_list_type,
 )
 
@@ -186,7 +187,7 @@ def convert_df_to_pa_scalar(df: pd.DataFrame, *, pa_type: pa.StructType | None) 
     types = {}
     columns = df.columns
     if pa_type is not None:
-        names = pa_type.names
+        names = struct_field_names(pa_type)
         columns = names + list(set(columns) - set(names))
     for column in columns:
         series = df[column]
@@ -913,7 +914,7 @@ class NestedExtensionArray(ExtensionArray):
     @property
     def field_names(self) -> list[str]:
         """Names of the nested columns"""
-        return [field for field in self._pyarrow_dtype.names]
+        return struct_field_names(self._pyarrow_dtype)
 
     @property
     def list_lengths(self) -> np.ndarray:

--- a/tests/nested_pandas/conftest.py
+++ b/tests/nested_pandas/conftest.py
@@ -1,0 +1,66 @@
+import importlib.metadata
+import re
+
+import pytest
+
+
+class TestUtils:
+    """Utility helpers for tests around package requirements and version guards.
+
+    Provides helpers to assert that our declared minimum versions for optional/required
+    dependencies don't exceed thresholds expected by tests.
+    """
+
+    @staticmethod
+    def fail_if_min_required_exceeds(dist_name: str, package: str, min_version_to_pass: int) -> None:
+        """Fail if the declared minimum required version for `package` exceeds allowed.
+
+        Parameters
+        ----------
+        dist_name : str
+            The installed distribution name to inspect for requirements (e.g., "nested-pandas").
+        package : str
+            The dependency package name to check (e.g., "pyarrow").
+        min_version_to_pass : int
+            The highest allowed minimum required a major version. The check fails if the
+            declared minimum is strictly greater than this value (e.g., pass 17 to allow
+            minimum<=17 and fail on >=18).
+
+        Behavior
+        --------
+        - Fails via pytest if the package is not found among requirements.
+        - Fails via pytest if the declared minimum version is greater than `min_version_to_pass`.
+        """
+        try:
+            import pytest  # imported lazily to avoid hard test dependency at runtime
+        except Exception as e:  # pragma: no cover - only used in tests
+            raise RuntimeError("pytest is required to use fail_if_min_required_exceeds in tests") from e
+
+        reqs = importlib.metadata.requires(dist_name)
+        if reqs is None:
+            pytest.fail(f"Could not find `{dist_name}` in `{package}`")
+        pkg_lower = package.lower()
+        min_required: int | None = None
+        for req in reqs:
+            # Match the package name at the start of the requirement line (extras/markers may follow)
+            if req.lower().startswith(pkg_lower):
+                m = re.search(r">=\s*(\d+)", req)
+                if m:
+                    min_required = int(m.group(1))
+                break
+        else:
+            pytest.fail(
+                f"Dependency '{package}' not found in project requirements for distribution '{dist_name}'"
+            )
+
+        if min_required is not None and min_required > min_version_to_pass:
+            pytest.fail(
+                f"Minimum required {package} version is >{min_version_to_pass}; please remove compatibility "
+                f"shims and use the newer API directly, then update or delete the tests using this guard."
+            )
+
+
+@pytest.fixture
+def test_utils():
+    """Pytest fixture exposing the TestUtils helper class for test modules."""
+    return TestUtils

--- a/tests/nested_pandas/series/test_series_utils.py
+++ b/tests/nested_pandas/series/test_series_utils.py
@@ -4,6 +4,7 @@ import pytest
 from nested_pandas import NestedDtype
 from nested_pandas.series.utils import (
     nested_types_mapper,
+    struct_field_names,
     transpose_list_struct_array,
     transpose_list_struct_scalar,
     transpose_list_struct_type,
@@ -123,6 +124,27 @@ def test_transpose_list_struct_scalar():
     desired = pa.scalar({"a": [1, 2], "b": ["x", "y"]})
     actual = transpose_list_struct_scalar(input_scalar)
     assert actual == desired
+
+
+def test_struct_field_names(test_utils):
+    """Test struct_field_names and guard against requirement bumps.
+
+    If the project's declared minimum required version of a dependency is bumped
+    beyond the threshold we accept, this test will fail and remind maintainers to
+    remove the compatibility shim and use the newer API directly everywhere.
+    """
+    test_utils.fail_if_min_required_exceeds("nested-pandas", "pyarrow", 17)
+
+    # Otherwise, validate the shim works as expected (for pyarrow<=17 requirement)
+    t = pa.struct(
+        [
+            pa.field("a", pa.list_(pa.int64())),
+            pa.field("b", pa.list_(pa.float64())),
+            pa.field("c", pa.list_(pa.string())),
+        ]
+    )
+    # Ensure we get names in the correct order
+    assert struct_field_names(t) == ["a", "b", "c"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This required a shim function, which should be removed in the future, when we finally drop old pyarrow versions. I've added a test to fail, so we wouldn't forget about it.

Written with a massive support from JetBrains' Junie

Fixes #326