### PR TITLE
Enable boolean masking through nest accessor

### DIFF
--- a/docs/tutorials/low_level.ipynb
+++ b/docs/tutorials/low_level.ipynb
@@ -297,6 +297,66 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7308a0a5",
+   "metadata": {},
+   "source": [
+    "## Use familiar pandas masking operations through the `.nest` accessor\n",
+    "\n",
+    "A popular usage pattern within pandas is the ability to filter `DataFrames`/`Series` using boolean masks. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a0a700f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nf = generate_data(5, 5, seed=1)\n",
+    "nf[nf[\"a\"] > 0.3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21395561",
+   "metadata": {},
+   "source": [
+    "In `nested-pandas`, the ability to do this masking is contained within the `.nest` accessor, which looks like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "156d0d71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nf = generate_data(5, 5, seed=1)\n",
+    "nf[\"nested.flag\"] = True  # Add an extra flag column\n",
+    "nf[\"nested\"].nest[(nf[\"nested.t\"] < 5) & nf[\"nested.flag\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ff4ee06",
+   "metadata": {},
+   "source": [
+    "The result here is a new nested column, with the masking applied, which we can assign back to the `nf` `NestedFrame` if we wish."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0f8dac3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nf[\"nested\"] = nf[\"nested\"].nest[(nf[\"nested.t\"] < 5) & nf[\"nested.flag\"]]\n",
+    "nf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "93f73bf28d48bfdc",
    "metadata": {},
    "source": [
@@ -735,7 +795,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "lsdb",
    "language": "python",
    "name": "python3"
   },
@@ -749,7 +809,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -226,6 +226,11 @@ class NestedFrame(pd.DataFrame):
         return super().__getitem__(item)
 
     def _getitem_str(self, item):
+
+        #if item in self.nested_columns:
+        #    # If the item is a nested column, return a flat dataframe
+        #    return super().__getitem__(item).nest.to_flat()
+
         # Preempt the nested check if the item is a base column, with or without
         # dots and backticks.
         if item in self.columns:

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -226,11 +226,6 @@ class NestedFrame(pd.DataFrame):
         return super().__getitem__(item)
 
     def _getitem_str(self, item):
-
-        #if item in self.nested_columns:
-        #    # If the item is a nested column, return a flat dataframe
-        #    return super().__getitem__(item).nest.to_flat()
-
         # Preempt the nested check if the item is a base column, with or without
         # dots and backticks.
         if item in self.columns:

--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -13,6 +13,7 @@ from pandas.api.extensions import register_series_accessor
 from nested_pandas.series.dtype import NestedDtype
 from nested_pandas.series.packer import pack_flat, pack_sorted_df_into_struct
 from nested_pandas.series.utils import nested_types_mapper
+from nested_pandas.nestedframe.core import NestedFrame
 
 __all__ = ["NestSeriesAccessor"]
 
@@ -479,6 +480,19 @@ class NestSeriesAccessor(Mapping):
         )
 
     def __getitem__(self, key: str | list[str]) -> pd.Series:
+
+        #import pdb;pdb.set_trace()
+        if isinstance(key, pd.Series) and pd.api.types.is_bool_dtype(key.dtype):
+            # Boolean masking
+            flat_df = self.to_flat()
+            if not key.index.equals(flat_df.index):
+                raise ValueError("Boolean mask must have the same index as the series")
+            # Apply the mask to the series
+            masked_df = flat_df[key]
+
+            nested_idx = NestedFrame(index=self._series.index)
+            return nested_idx.add_nested(masked_df, name=self._series.name)
+
         if isinstance(key, list):
             new_array = self._series.array.view_fields(key)
             return pd.Series(new_array, index=self._series.index, name=self._series.name)


### PR DESCRIPTION
Allows boolean masking through the nest accessor, e.g.:
`nf["nested"].nest[nf["nested.t"] < 5]`

Takes a step towards #274, but wouldn't neccesarily say this resolves it. As we discussed, this step is mainly to see how the implementation feels when centered on the .nest accessor, but we may move to a more direct nested series implementation #304 in the future

Performance looks comparable to NestedFrame.query, with a bit less overhead perhaps