### PR TITLE
Better filesystem selection for `read_parquet`

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -179,10 +179,10 @@ def _transform_read_parquet_data_arg(data):
     # Check if a file-like object
     if hasattr(data, "read"):
         return data, None
-        # Check if `data` is a Path
     # Check if `data` is a UPath and use it
     if isinstance(data, UPath):
         return data.path, data.fs
+    # Check if `data` is a Path (Path is a superclass for UPath, so this order of checks)
     if isinstance(data, Path):
         return data, None
     # It should be a string now


### PR DESCRIPTION
I reimplement what was done in #318, because previously we use fsspec for local files, while we probably want to use pyarrow filesystem for that.