### PR TITLE
Use fsspec.parquet for reading remote Parquet files

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -254,3 +254,27 @@ class ReadFewColumnsHTTPS:
     def peakmem_run(self):
         """Benchmark the memory usage of read_parquet(self.path, columns=self.columns)"""
         self.run()
+
+
+class ReadFewColumnsHTTPSWithOptimization:
+    """Benchmark read_parquet("https://", columns=[...])
+
+    Note: fsspec optimization is now automatic for remote URLs,
+    so this benchmark is equivalent to ReadFewColumnsHTTPS.
+    Kept for historical comparison purposes.
+    """
+
+    path = "https://data.lsdb.io/hats/gaia_dr3/gaia/dataset/Norder=2/Dir=0/Npix=0.parquet"
+    columns = ["_healpix_29", "ra", "astrometric_primary_flag"]
+
+    def run(self):
+        """Run the benchmark (fsspec optimization is automatic for remote URLs)."""
+        _ = read_parquet(self.path, columns=self.columns)
+
+    def time_run(self):
+        """Benchmark the runtime with automatic fsspec optimization"""
+        self.run()
+
+    def peakmem_run(self):
+        """Benchmark the memory usage with automatic fsspec optimization"""
+        self.run()


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
Following the recommendations in [this NVIDIA blog post](https://developer.nvidia.com/blog/optimizing-access-to-parquet-data-with-fsspec/), use `fsspec.parquet.open_parquet_file` when the path to the Parquet file indicates that it is remote.

Closes #365 .

- [X] My PR includes a link to the issue that I am addressing

## Solution Description
As the blog post describes, this optimization avoids the typical read-ahead strategy that works well for local files, in favor of making more precise reads that use less bandwidth.

The improvement in wall-clock time varies greatly depending on the use case.  Testing this change using the PANSTARRS catalog:

|Operation           |Before   |After |
|--------------------|---------|------|
|`.head()`           |   3.61s |1.57s |
|mean of one column  |   3h 3m |2h 55m|
|`.random_sample`    |   2m 36s|2m 36s|

In no case does the `fsspec.parquet` result in *slower* times, so it seems worth doing, even if it's not a dramatic improvement across the board.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists

### New Feature Checklist
- [X] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [X] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

