### PR TITLE
Add missing filesystem on parquet read call

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -246,7 +246,7 @@ def _read_parquet_into_table(
 def _read_table_with_partial_load_check(data, columns=None, filesystem=None, **kwargs):
     """Read a pyarrow table with partial load check for nested structures"""
     try:
-        return pq.read_table(data, columns=columns, **kwargs)
+        return pq.read_table(data, columns=columns, filesystem=filesystem, **kwargs)
     except ArrowInvalid as e:
         # if it's not related to partial loading of nested structures, re-raise
         if "No match for" not in str(e):


### PR DESCRIPTION
The missing keyword argument was detected by the `hats-cloudtests` [smoke tests](https://github.com/astronomy-commons/hats-cloudtests/actions/runs/19127389749). [Here](https://github.com/astronomy-commons/hats-cloudtests/actions/runs/19141267088) is a successful run after the fix.