### PR TITLE
Make most of `map_rows` arguments to be keyword-only

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -1997,6 +1997,7 @@ class NestedFrame(pd.DataFrame):
         self,
         func: Callable[..., Any],
         columns: None | str | list[str] = None,
+        *,
         row_container: Literal["dict"] | Literal["args"] = "dict",
         output_names: None | str | list[str] = None,
         infer_nesting: bool = True,


### PR DESCRIPTION
Closes #415 