### PR TITLE
Display non-existing nested columns in error message

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -255,7 +255,8 @@ class NestedFrame(pd.DataFrame):
         else:
             raise KeyError(f"Column '{cleaned_item}' not found in nested columns or base columns")
 
-    def _is_key_list(self, item):
+    @staticmethod
+    def _is_key_list(item):
         if not is_list_like(item):
             return False
         if is_bool_dtype(item):
@@ -263,11 +264,11 @@ class NestedFrame(pd.DataFrame):
         for k in item:
             if not isinstance(k, str):
                 return False
-            if not self._is_known_column(k):
-                return False
         return True
 
     def _getitem_list(self, item):
+        unknown_cols = [k for k in item if not self._is_known_column(k)]
+        super().__getitem__(unknown_cols)
         non_nested_keys = [k for k in item if k in self.columns]
         result = super().__getitem__(non_nested_keys)
         components = [self._parse_hierarchical_components(k) for k in item]

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -268,7 +268,8 @@ class NestedFrame(pd.DataFrame):
 
     def _getitem_list(self, item):
         unknown_cols = [k for k in item if not self._is_known_column(k)]
-        super().__getitem__(unknown_cols)
+        if unknown_cols:
+            raise KeyError(f"{unknown_cols} not in index")
         non_nested_keys = [k for k in item if k in self.columns]
         result = super().__getitem__(non_nested_keys)
         components = [self._parse_hierarchical_components(k) for k in item]

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -261,10 +261,7 @@ class NestedFrame(pd.DataFrame):
             return False
         if is_bool_dtype(item):
             return False
-        for k in item:
-            if not isinstance(k, str):
-                return False
-        return True
+        return all(isinstance(k, str) for k in item)
 
     def _getitem_list(self, item):
         unknown_cols = [k for k in item if not self._is_known_column(k)]

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -246,14 +248,17 @@ def test_get_nested_columns_errors():
 
     base = base.join_nested(nested, "nested")
 
-    with pytest.raises(KeyError):
-        base[["a", "c"]]
+    with pytest.raises(KeyError, match=re.escape("['c']")):
+        _ = base[["a", "c"]]
 
-    with pytest.raises(KeyError):
-        base[["a", "nested.g"]]
+    with pytest.raises(KeyError, match=re.escape("['nested.g']")):
+        _ = base[["a", "nested.c", "nested.g"]]
 
-    with pytest.raises(KeyError):
-        base[["a", "nested.a", "wrong.b"]]
+    with pytest.raises(KeyError, match=re.escape("['wrong.b']")):
+        _ = base[["a", "nested.c", "wrong.b"]]
+
+    with pytest.raises(KeyError, match="['c', 'wrong.b']"):
+        _ = base[["c", "nested.c", "wrong.b"]]
 
 
 def test_getitem_empty_bool_array():

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -248,16 +248,14 @@ def test_get_nested_columns_errors():
 
     base = base.join_nested(nested, "nested")
 
+    # Escaping the list of columns for a strict check
     with pytest.raises(KeyError, match=re.escape("['c']")):
         _ = base[["a", "c"]]
-
     with pytest.raises(KeyError, match=re.escape("['nested.g']")):
         _ = base[["a", "nested.c", "nested.g"]]
-
     with pytest.raises(KeyError, match=re.escape("['wrong.b']")):
         _ = base[["a", "nested.c", "wrong.b"]]
-
-    with pytest.raises(KeyError, match="['c', 'wrong.b']"):
+    with pytest.raises(KeyError, match=re.escape("['c', 'wrong.b']")):
         _ = base[["c", "nested.c", "wrong.b"]]
 
 


### PR DESCRIPTION
When selecting columns for a `NestedFrame`, ensure that the error message only lists non-existent nested columns specified by the user. Previously, all specified nested columns would appear. Closes https://github.com/astronomy-commons/lsdb/issues/1017.