### PR TITLE
Fix empty-list HTML representation

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -123,7 +123,7 @@ class NestedFrame(pd.DataFrame):
         # Display nested columns as small html dataframes with a single row
         def repack_row(chunk, header=True):
             # If the chunk is None, just return None
-            if chunk is None:
+            if chunk is None or len(chunk) == 0:
                 return None
             # Grab length, then truncate to one row for display
             n_rows = len(chunk)

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -72,6 +72,15 @@ def test_html_repr():
     nf._repr_html_()
 
 
+def test_html_repr_empty_list():
+    """Make sure the html representation handles empty lists correctly"""
+    base = NestedFrame(data={"a": [1, 2], "b": [2, 4], "c": [[1, 2, 3], []]}, index=[0, 1])
+    base = base.nest_lists(columns=["c"], name="nested")
+    assert base["nested"].iloc[1].empty
+    html = base._repr_html_()
+    assert "+-1 rows" not in html and "None" in html
+
+
 def test_all_columns():
     """Test the all_columns function"""
 


### PR DESCRIPTION
It now displays "None" instead of "c" with "+- 1 rows".
 
<img width="676" height="262" alt="Screenshot 2026-01-07 at 12 18 28 PM" src="https://github.com/user-attachments/assets/77f2e912-8979-4fa5-a2f4-0736931a1120" />

Closes #377.