### PR TITLE
Add is_dir shortcut for skipping directory checks

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -226,7 +226,7 @@ class ReadFewColumnsS3:
 
     def run(self):
         """Run the benchmark."""
-        _ = read_parquet(self.path, columns=self.columns)
+        _ = read_parquet(self.path, columns=self.columns, is_dir=False)
 
     def time_run(self):
         """Benchmark the runtime of read_parquet(self.path, columns=self.columns)"""
@@ -245,7 +245,7 @@ class ReadFewColumnsHTTPS:
 
     def run(self):
         """Run the benchmark."""
-        _ = read_parquet(self.path, columns=self.columns)
+        _ = read_parquet(self.path, columns=self.columns, is_dir=False)
 
     def time_run(self):
         """Benchmark the runtime of read_parquet(self.path, columns=self.columns)"""

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -78,9 +78,9 @@ def read_parquet(
         If True, the pointer represents a pixel directory; if False, the pointer
         represents a file. In both cases there is no need to check the pointer's
         content type. If `is_dir` is None (default), this method will resort to
-        `upath.is_dir()` to identify the type of pointer. Inferring the type for
-        HTTP is particularly expensive because it requires downloading the contents
-        of the pointer in its entirety.
+        `upath.is_dir()` to identify the type of pointer. This argument is ignored
+        for HTTP, as inferring the type for HTTP is particularly expensive because
+        it requires downloading the contents of the pointer in its entirety.
     kwargs: dict
         Keyword arguments passed to `pyarrow.parquet.read_table`
 

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -320,11 +320,12 @@ def _is_remote_dir(orig_data: str | Path | UPath, upath: UPath, is_dir: bool | N
     # See details in _read_parquet_into_table docstring.
     if upath.protocol in NO_ITERDIR_FILESYSTEMS:
         return False
+    if is_dir is not None:
+        return is_dir
     if str(orig_data).endswith("/"):
         return True
     if is_dir is None:
         return upath.is_dir()
-    return is_dir
 
 
 def _read_remote_parquet_directory(

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -75,7 +75,7 @@ def read_parquet(
     autocast_list: bool, default=True
         If True, automatically cast list columns to nested columns with NestedDType.
     is_dir: bool, None, default=None
-        If True, the pointer represents a pixel directory, otherwise, the pointer
+        If True, the pointer represents a pixel directory; if False, the pointer
         represents a file. In both cases there is no need to check the pointer's
         content type. If `is_dir` is None (default), this method will resort to
         `upath.is_dir()` to identify the type of pointer. Inferring the type for
@@ -309,10 +309,7 @@ def _is_local_dir(upath: UPath, is_dir: bool | None) -> bool:
         return False
     # For local filesystems, check is_dir if provided, otherwise use upath.is_dir()
     else:
-        if is_dir is None:
-            return upath.is_dir()
-        else:
-            return is_dir
+        return upath.is_dir() if is_dir is None else is_dir
 
 
 def _is_remote_dir(orig_data: str | Path | UPath, upath: UPath, is_dir: bool | None) -> bool:

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -303,9 +303,16 @@ def _is_local_dir(upath: UPath, is_dir: bool | None) -> bool:
     ``UPath(p).is_dir()``, because ``UPath.is_dir`` can be quite
     expensive in the case of a remote file path that isn't a directory.
     """
-    if is_dir is None:
-        is_dir = upath.is_dir()
-    return upath.protocol in ("", "file") and is_dir
+
+    # For non-local filesystems, return False right away
+    if upath.protocol not in ("", "file"):
+        return False
+    # For local filesystems, check is_dir if provided, otherwise use upath.is_dir()
+    else:
+        if is_dir is None:
+            return upath.is_dir()
+        else:
+            return is_dir
 
 
 def _is_remote_dir(orig_data: str | Path | UPath, upath: UPath, is_dir: bool | None) -> bool:

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -461,6 +461,60 @@ def test__get_storage_options():
     assert storage_opts.get("block_size") != FSSPEC_BLOCK_SIZE
 
 
+def test__is_local_dir():
+    """Test the _is_local_dir function with various scenarios."""
+    from nested_pandas.nestedframe.io import _is_local_dir
+
+    # Local path that is a directory
+    local_dir = UPath("tests/test_data")
+    assert _is_local_dir(local_dir, is_dir=True) is True
+    assert _is_local_dir(local_dir, is_dir=False) is False
+    assert _is_local_dir(local_dir, is_dir=None) is True
+
+    # Local path that is a file
+    local_file = UPath("tests/test_data/nested.parquet")
+    assert _is_local_dir(local_file, is_dir=True) is True
+    assert _is_local_dir(local_file, is_dir=False) is False
+    assert _is_local_dir(local_file, is_dir=None) is False
+
+    # Remote path (should always return False)
+    remote_path = UPath("https://example.com/data.parquet")
+    assert _is_local_dir(remote_path, is_dir=True) is False
+    assert _is_local_dir(remote_path, is_dir=False) is False
+    assert _is_local_dir(remote_path, is_dir=None) is False
+
+
+def test__is_remote_dir():
+    """Test the _is_remote_dir function with various scenarios."""
+    from nested_pandas.nestedframe.io import _is_remote_dir
+
+    # Local path that is a directory
+    local_dir = UPath("tests/test_data")
+    assert _is_remote_dir("tests/test_data", local_dir, is_dir=True) is True
+    assert _is_remote_dir("tests/test_data", local_dir, is_dir=False) is False
+    assert _is_remote_dir("tests/test_data", local_dir, is_dir=None) is True
+
+    # Local path that is a file
+    local_file = UPath("tests/test_data/nested.parquet")
+    assert _is_remote_dir("tests/test_data/nested.parquet", local_file, is_dir=True) is True
+    assert _is_remote_dir("tests/test_data/nested.parquet", local_file, is_dir=False) is False
+    assert _is_remote_dir("tests/test_data/nested.parquet", local_file, is_dir=None) is False
+
+    # Remote file path
+    remote_path = UPath("https://example.com/data.parquet")
+    # In this case, the override is overruled by a protocol check
+    assert _is_remote_dir("https://example.com/data.parquet", remote_path, is_dir=True) is False
+    assert _is_remote_dir("https://example.com/data.parquet", remote_path, is_dir=False) is False
+    assert _is_remote_dir("https://example.com/data.parquet", remote_path, is_dir=None) is False
+
+    # Remote directory path
+    remote_dir_path = UPath("https://example.com/data/")
+    # Also overruled by protocol check not supporting https
+    assert _is_remote_dir("https://example.com/data/", remote_dir_path, is_dir=True) is False
+    assert _is_remote_dir("https://example.com/data/", remote_dir_path, is_dir=False) is False
+    assert _is_remote_dir("https://example.com/data/", remote_dir_path, is_dir=None) is False
+
+
 def test_list_struct_partial_loading_error():
     """Test that attempting to partially load a list-struct raises an error."""
     # Load in the example file


### PR DESCRIPTION
Closes #408 

Adds an is_dir override that plugs into the `_is_local_dir` and `_is_remote_dir` helper functions, which allows `npd.read_parquet(..., is_dir=True/False)` to apply the override. 

This override isn't absolute for the remote check, as it currently prohibits remote HTTP file directories. I am not sure if providing this override should actually allow HTTP directories with the main concerns being the cost of .is_dir() and potentially iter_dir()