### PR TITLE
Append sub-columns via `map_rows`

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -2045,7 +2045,7 @@ class NestedFrame(pd.DataFrame):
             The output columns can contain nested sub-columns, which should be specified using their
             hierarchical column name (e.g. "nested.x"). If their base nested column exists in the
             original NestedFrame, the new output sub-columns will be added into the frame of the
-            existing nested column. See an example in the Notes.
+            existing nested column. See an example below.
         kwargs : keyword arguments, optional
             Keyword arguments to pass to the function.
 

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -2260,8 +2260,15 @@ class NestedFrame(pd.DataFrame):
                 results_nf[layer] = nested_col
 
         if append_columns:
-            # Append the results to the original NestedFrame
-            return pd.concat([self, results_nf], axis=1)
+            # Append sub-columns to existing nested columns
+            self_nested_cols = [col for col in results_nf.nested_columns if col in self.nested_columns]
+            for col in self_nested_cols:
+                sub_columns = results_nf.get_subcolumns(col)
+                for sub_col in sub_columns:
+                    self = self.assign(**{f"{sub_col}": results_nf[sub_col]})
+            # Append other base and nested columns
+            base_results_nf = results_nf.drop(columns=self_nested_cols)
+            return pd.concat([self, base_results_nf], axis=1)
 
         # Otherwise, return the results as a new NestedFrame
         return results_nf


### PR DESCRIPTION
When using `map_rows(..., append_columns=True)`, allow appending a nested sub-column to an existing `NestedFrame`. Previously, specifying a sub-column for an existing nested column would create a new nested column with the same name.

Closes #347.