### PR TITLE
Allow str inputs for series/accessor methods: `explode`, `to_flat`, `to_lists`

### DIFF
--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -41,13 +41,13 @@ class NestSeriesAccessor(Mapping):
         if not isinstance(dtype, NestedDtype):
             raise AttributeError(f"Can only use .nest accessor with a Series of NestedDtype, got {dtype}")
 
-    def to_lists(self, columns: list[str] | None = None) -> pd.DataFrame:
+    def to_lists(self, columns: list[str] | str | None = None) -> pd.DataFrame:
         """Convert nested series into dataframe of list-array columns
 
         Parameters
         ----------
-        columns : list[str] or None, optional
-            Names of the columns to include. Default is None, which means all columns.
+        columns : list[str] or str or None, optional
+            Names of the column(s) to include. Default is None, which means all columns.
 
         Returns
         -------
@@ -69,6 +69,10 @@ class NestSeriesAccessor(Mapping):
         4    [0.54775186 3.96202978]  [87.63891523 87.81425034]  ['g' 'r']
         """
         columns = columns if columns is not None else list(self._series.array.field_names)
+
+        if isinstance(columns, str):
+            columns = [columns]
+
         if len(columns) == 0:
             raise ValueError("Cannot convert a struct with no fields to lists")
 
@@ -77,13 +81,13 @@ class NestSeriesAccessor(Mapping):
 
         return list_df
 
-    def to_flat(self, columns: list[str] | None = None) -> pd.DataFrame:
+    def to_flat(self, columns: list[str] | str | None = None) -> pd.DataFrame:
         """Convert nested series into dataframe of flat arrays
 
         Parameters
         ----------
-        columns : list[str] or None, optional
-            Names of the columns to include. Default is None, which means all columns.
+        columns : list[str] or str or None, optional
+            Names of the column(s) to include. Default is None, which means all columns.
 
         Returns
         -------
@@ -111,6 +115,10 @@ class NestSeriesAccessor(Mapping):
 
         """
         columns = columns if columns is not None else list(self._series.array.field_names)
+
+        if isinstance(columns, str):
+            columns = [columns]
+
         if len(columns) == 0:
             raise ValueError("Cannot flatten a struct with no columns")
 

--- a/src/nested_pandas/series/nestedseries.py
+++ b/src/nested_pandas/series/nestedseries.py
@@ -135,13 +135,13 @@ class NestedSeries(pd.Series):
         return self.explode(columns=fields)
 
     @nested_only
-    def explode(self, columns: list[str] | None = None) -> pd.DataFrame:
+    def explode(self, columns: list[str] | str | None = None) -> pd.DataFrame:
         """Unpack nested series into dataframe of flat arrays.
 
         Parameters
         ----------
-        columns : list[str] or None, optional
-            Names of the columns to include. Default is None, which means all columns.
+        columns : list[str] or str or None, optional
+            Names of the column(s) to include. Default is None, which means all columns.
 
         Returns
         -------
@@ -171,13 +171,13 @@ class NestedSeries(pd.Series):
         return self.nest.to_flat(columns=columns)
 
     @nested_only
-    def to_lists(self, columns: list[str] | None = None) -> pd.DataFrame:
+    def to_lists(self, columns: list[str] | str | None = None) -> pd.DataFrame:
         """Convert nested series into dataframe of list-array columns.
 
         Parameters
         ----------
-        columns : list[str] or None, optional
-            Names of the columns to include. Default is None, which means all columns.
+        columns : list[str] or str or None, optional
+            Names of the column(s) to include. Default is None, which means all columns.
 
         Returns
         -------

--- a/tests/nested_pandas/series/test_nestedseries.py
+++ b/tests/nested_pandas/series/test_nestedseries.py
@@ -209,6 +209,23 @@ def test_nestedseries_explode():
     assert flat_df.shape == (4, 2)
 
 
+def test_nestedseries_explode_single_column():
+    """Test explode method of NestedSeries for a single column."""
+    series = NestedSeries(
+        data=[
+            (np.array([1, 2]), np.array([0, 1])),
+            (np.array([3, 4]), np.array([0, 1])),
+        ],
+        index=[0, 1],
+        dtype=NestedDtype(pa.struct([("a", pa.list_(pa.int64())), ("b", pa.list_(pa.int64()))])),
+    )
+
+    flat_series = series.explode(columns="a")
+    assert isinstance(flat_series, pd.DataFrame)
+    assert flat_series.columns == ["a"]
+    assert flat_series.shape == (4, 1)
+
+
 def test_nestedseries_to_lists():
     """Test to_lists method of NestedSeries."""
     series = NestedSeries(
@@ -221,6 +238,23 @@ def test_nestedseries_to_lists():
     )
 
     lists = series.to_lists()
+    assert len(lists) == 2
+    assert lists["a"][0] == [1, 2]
+    assert lists["a"][1] == [3, 4]
+
+
+def test_nestedseries_to_lists_single_column():
+    """Test to_lists method of NestedSeries for a single column."""
+    series = NestedSeries(
+        data=[
+            (np.array([1, 2]), np.array([0, 1])),
+            (np.array([3, 4]), np.array([0, 1])),
+        ],
+        index=[0, 1],
+        dtype=NestedDtype(pa.struct([("a", pa.list_(pa.int64())), ("b", pa.list_(pa.int64()))])),
+    )
+
+    lists = series.to_lists(columns="a")
     assert len(lists) == 2
     assert lists["a"][0] == [1, 2]
     assert lists["a"][1] == [3, 4]


### PR DESCRIPTION
Fixes #381 
