### PR TITLE
pin fsspec<2025.12.0 and add issue 428 test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pyarrow>=16",  # remove struct_field_names() and struct_fields() when upgraded to 18+
     "Deprecated>=1.2.0",
     "wrapt>=1.12.1",
-    "fsspec>=2025.7.0",
+    "fsspec>=2025.7.0, <2025.12.0",
     "universal_pathlib>=0.3.1",
 ]
 

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -541,3 +541,18 @@ def test_read_parquet_with_fixed_length_list_struct():
     nf = read_parquet("tests/fixed_size_list_data/fixed-size-list-struct.parquet")
     assert nf.shape == (5, 3)
     assert nf.nested_columns == ["fixed_nested"]
+
+
+@pytest.mark.parametrize("size", [5000, 500_000, 5_000_000])
+def test_issue_428(size):
+    """Partial loading fsspec issue: https://github.com/lincc-frameworks/nested-pandas/issues/428"""
+
+    # Initialize a temp file
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = os.path.join(tmpdir, "tmp.parquet")
+
+        # Generate and write the data
+        generate_data(size, 3).to_parquet(file_path)
+        nf = read_parquet(file_path, columns=["nested.t"])
+        assert nf.columns == ["nested"]
+        assert nf.nested.nest.columns == ["t"]


### PR DESCRIPTION
Allows failing case in #428 to work by pinning fsspec to avoid a recent regression, and adds a direct test that should fail in response to this regression. This shouldn't neccesarily close the issue as we would like to eventually have latest fsspec working, tracker issue for that: https://github.com/fsspec/filesystem_spec/issues/1973