### PR TITLE
Change fsspec version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pyarrow>=16",  # remove struct_field_names() and struct_fields() when upgraded to 18+
     "Deprecated>=1.2.0",
     "wrapt>=1.12.1",
-    "fsspec>=2025.7.0, <2025.12.0",
+    "fsspec>=2025.7.0,!=2025.12,!=2026.1",  # Avoiding https://github.com/fsspec/filesystem_spec/issues/1973
     "universal_pathlib>=0.3.1",
 ]
 


### PR DESCRIPTION
Bump `fsspec` to  use versions [2025.7, 2025.11] and >2026.2 to avoid https://github.com/fsspec/filesystem_spec/issues/1973