### PR TITLE
Improve error message for pack_flat with NaN values in index

### DIFF
--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -152,7 +152,6 @@ def pack_seq(
     return series
 
 
-
 def pack_sorted_df_into_struct(df: pd.DataFrame, name: str | None = None) -> NestedSeries:
     """Make a structure of lists representation of a "flat" dataframe.
 

--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -93,7 +93,6 @@ def pack_flat(
     nested_pandas.series.dtype.NestedDtype : The dtype of the output series.
     nested_pandas.series.packer.pack_lists : Pack a dataframe of nested arrays.
     """
-    original_on = on
     if on is not None:
         df = df.set_index(on)
     # pandas knows when index is pre-sorted, so it would do nothing if it is already sorted
@@ -103,18 +102,18 @@ def pack_flat(
     except ValueError:
         # Check if the error is due to NaN values and raise a more informative message
         if any(sorted_flat.index.get_level_values(i).hasnans for i in range(sorted_flat.index.nlevels)):
-            if original_on is not None:
-                cols = [original_on] if isinstance(original_on, str) else list(original_on)
+            if on is None:
                 raise ValueError(
-                    f"Column(s) {cols} contain NaN values. "
+                    "The index contains NaN values. "
                     "NaN values are not supported because they cannot be used for grouping rows. "
                     "Please remove or fill NaN values before packing."
-                )
+                ) from None
+            cols = [on] if isinstance(on, str) else list(on)
             raise ValueError(
-                "The index contains NaN values. "
+                f"Column(s) {cols} contain NaN values. "
                 "NaN values are not supported because they cannot be used for grouping rows. "
                 "Please remove or fill NaN values before packing."
-            )
+            ) from None
         raise
 
 

--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -95,7 +95,29 @@ def pack_flat(
     """
 
     if on is not None:
+        if isinstance(on, str):
+            cols = [on]
+        else:
+            cols = list(on)
+        if df[cols].isna().any().any():
+            raise ValueError(
+                f"Column(s) {cols} contain NaN values. "
+                "NaN values are not supported because they cannot be used for grouping rows. "
+                "Please remove or fill NaN values before packing."
+            )
         df = df.set_index(on)
+    else:
+        try:
+            has_nans = df.index.isna().any()
+        except NotImplementedError:
+            # MultiIndex does not support isna()
+            has_nans = False
+        if has_nans:
+            raise ValueError(
+                "The index contains NaN values. "
+                "NaN values are not supported because they cannot be used for grouping rows. "
+                "Please remove or fill NaN values before packing."
+            )
     # pandas knows when index is pre-sorted, so it would do nothing if it is already sorted
     sorted_flat = df.sort_index(kind="stable")
     return pack_sorted_df_into_struct(sorted_flat, name=name)

--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -104,7 +104,7 @@ def pack_flat(
                     "Please remove or fill NaN values before packing."
                 )
         df = df.set_index(on)
-    elif not isinstance(df.index, pd.MultiIndex) and df.index.hasnans:
+    elif any(df.index.get_level_values(i).hasnans for i in range(df.index.nlevels)):
         raise ValueError(
             "The index contains NaN values. "
             "NaN values are not supported because they cannot be used for grouping rows. "

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -616,6 +616,24 @@ def test_pack_flat_raises_with_nan_in_index():
         packer.pack_flat(df)
 
 
+def test_pack_flat_raises_with_nan_in_multiindex():
+    """Test pack_flat() raises informative error when MultiIndex contains NaN values.
+
+    This is a regression test for https://github.com/lincc-frameworks/nested-pandas/issues/440
+    """
+    df = pd.DataFrame(
+        data={
+            "a": [1, 2, 3, 4, 5],
+            "b": [0, 1, 0, 1, 0],
+        },
+        index=pd.MultiIndex.from_arrays(
+            ([1, 1, 2, 2, 2], [1.0, 2.0, np.nan, 1.0, 2.0]),
+        ),
+    )
+    with pytest.raises(ValueError, match="The index contains NaN values"):
+        packer.pack_flat(df)
+
+
 @pytest.mark.parametrize(
     "col_data,col_dtype",
     [

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -600,7 +600,14 @@ def test_calculate_sorted_index_offsets_raises_when_not_sorted():
         packer.calculate_sorted_index_offsets(index)
 
 
-def test_pack_flat_raises_with_nan_in_index():
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.Index([1.0, 1.0, 2.0, 2.0, np.nan]),
+        pd.MultiIndex.from_arrays(([1, 1, 2, 2, 2], [1.0, 2.0, np.nan, 1.0, 2.0])),
+    ],
+)
+def test_pack_flat_raises_with_nan_in_index(index):
     """Test pack_flat() raises informative error when index contains NaN values.
 
     This is a regression test for https://github.com/lincc-frameworks/nested-pandas/issues/440
@@ -610,25 +617,7 @@ def test_pack_flat_raises_with_nan_in_index():
             "a": [1, 2, 3, 4, 5],
             "b": [0, 1, 0, 1, 0],
         },
-        index=[1.0, 1.0, 2.0, 2.0, np.nan],
-    )
-    with pytest.raises(ValueError, match="The index contains NaN values"):
-        packer.pack_flat(df)
-
-
-def test_pack_flat_raises_with_nan_in_multiindex():
-    """Test pack_flat() raises informative error when MultiIndex contains NaN values.
-
-    This is a regression test for https://github.com/lincc-frameworks/nested-pandas/issues/440
-    """
-    df = pd.DataFrame(
-        data={
-            "a": [1, 2, 3, 4, 5],
-            "b": [0, 1, 0, 1, 0],
-        },
-        index=pd.MultiIndex.from_arrays(
-            ([1, 1, 2, 2, 2], [1.0, 2.0, np.nan, 1.0, 2.0]),
-        ),
+        index=index,
     )
     with pytest.raises(ValueError, match="The index contains NaN values"):
         packer.pack_flat(df)

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -628,5 +628,5 @@ def test_pack_flat_raises_with_nan_in_on_column():
             "c": [1.0, 1.0, 2.0, 2.0, np.nan],
         },
     )
-    with pytest.raises(ValueError, match=r"Column\(s\) \['c'\] contain NaN values"):
+    with pytest.raises(ValueError, match="Column 'c' contains NaN values"):
         packer.pack_flat(df, on="c")

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -612,7 +612,7 @@ def test_pack_flat_raises_with_nan_in_index():
         },
         index=[1.0, 1.0, 2.0, 2.0, np.nan],
     )
-    with pytest.raises(ValueError, match="contains NaN values"):
+    with pytest.raises(ValueError, match="The index contains NaN values"):
         packer.pack_flat(df)
 
 
@@ -628,5 +628,5 @@ def test_pack_flat_raises_with_nan_in_on_column():
             "c": [1.0, 1.0, 2.0, 2.0, np.nan],
         },
     )
-    with pytest.raises(ValueError, match="contains NaN values"):
+    with pytest.raises(ValueError, match=r"Column\(s\) \['c'\] contain NaN values"):
         packer.pack_flat(df, on="c")

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -598,3 +598,35 @@ def test_calculate_sorted_index_offsets_raises_when_not_sorted():
     index = pd.Index([1, 2, 1, 2, 3, 3, 4, 4, 4])
     with pytest.raises(ValueError):
         packer.calculate_sorted_index_offsets(index)
+
+
+def test_pack_flat_raises_with_nan_in_index():
+    """Test pack_flat() raises informative error when index contains NaN values.
+
+    This is a regression test for https://github.com/lincc-frameworks/nested-pandas/issues/440
+    """
+    df = pd.DataFrame(
+        data={
+            "a": [1, 2, 3, 4, 5],
+            "b": [0, 1, 0, 1, 0],
+        },
+        index=[1.0, 1.0, 2.0, 2.0, np.nan],
+    )
+    with pytest.raises(ValueError, match="contains NaN values"):
+        packer.pack_flat(df)
+
+
+def test_pack_flat_raises_with_nan_in_on_column():
+    """Test pack_flat() raises informative error when 'on' column contains NaN values.
+
+    This is a regression test for https://github.com/lincc-frameworks/nested-pandas/issues/440
+    """
+    df = pd.DataFrame(
+        data={
+            "a": [1, 2, 3, 4, 5],
+            "b": [0, 1, 0, 1, 0],
+            "c": [1.0, 1.0, 2.0, 2.0, np.nan],
+        },
+    )
+    with pytest.raises(ValueError, match="contains NaN values"):
+        packer.pack_flat(df, on="c")

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -616,7 +616,14 @@ def test_pack_flat_raises_with_nan_in_index():
         packer.pack_flat(df)
 
 
-def test_pack_flat_raises_with_nan_in_on_column():
+@pytest.mark.parametrize(
+    "col_data,col_dtype",
+    [
+        ([1.0, 1.0, 2.0, 2.0, np.nan], None),
+        ([1.0, 1.0, 2.0, 2.0, None], pd.ArrowDtype(pa.float64())),
+    ],
+)
+def test_pack_flat_raises_with_nan_in_on_column(col_data, col_dtype):
     """Test pack_flat() raises informative error when 'on' column contains NaN values.
 
     This is a regression test for https://github.com/lincc-frameworks/nested-pandas/issues/440
@@ -625,7 +632,7 @@ def test_pack_flat_raises_with_nan_in_on_column():
         data={
             "a": [1, 2, 3, 4, 5],
             "b": [0, 1, 0, 1, 0],
-            "c": [1.0, 1.0, 2.0, 2.0, np.nan],
+            "c": pd.array(col_data, dtype=col_dtype),
         },
     )
     with pytest.raises(ValueError, match="Column 'c' contains NaN values"):

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -642,5 +642,5 @@ def test_pack_flat_raises_with_nan_in_on_column(col_data, col_dtype):
             "c": pd.array(col_data, dtype=col_dtype),
         },
     )
-    with pytest.raises(ValueError, match="Column 'c' contains NaN values"):
+    with pytest.raises(ValueError, match=r"Column\(s\) \['c'\] contain NaN values"):
         packer.pack_flat(df, on="c")


### PR DESCRIPTION
When the index contains NaN values, is_monotonic_increasing returns
False, causing a misleading "index must be sorted" error. Now we check
for NaN values when monotonicity fails and raise a specific error
explaining that NaN values are not supported for grouping.

Fixes #440

https://claude.ai/code/session_01F7cbsuGUbfDoW1oDdiGqf5