### PR TITLE
Add slack message when smoke test fails

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -48,4 +48,52 @@ jobs:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook
         payload: |
-          text: "Smoke test failed ${{ matrix.python-version }}"
+          {
+            "text": "🚨 Smoke Test Failed (Python ${{ matrix.python-version }})",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "🚨 Smoke Test Failed",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Component:*\n`nested-pandas`"
+                  }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View Test Logs",
+                      "emoji": true
+                    },
+                    "style": "danger",
+                    "url": "https://github.com/lincc-frameworks/nested-pandas/actions/runs/${{ github.run_id }}"
+                  }
+                ]
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "🤖 _Automated Alert from Python CI Pipeline_"
+                  }
+                ]
+              },
+              {
+                "type": "divider"
+              }
+            ]
+          }


### PR DESCRIPTION
## Change Description
Closes #453 

## Solution Description
Slack has an officially maintained github actions service that can be used here.
It sends the message directly to the designated slack channel.

It needs a `secret` to be added to the repo - the `SLACK_WEBHOOK_URL` which can be generated form the slack app itself.

Reference for the code: [Official slack documentation](https://docs.slack.dev/tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/)

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
