### PR TITLE
Run pytest in CI using the latest `pandas` v3 pre-releases

### DIFF
--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -9,10 +9,9 @@
 name: Test against pandas development version
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  schedule:
+    - cron: 45 6 * * *
+  workflow_dispatch:
 
 jobs:
   test-pandas-dev:
@@ -40,19 +39,19 @@ jobs:
           uv pip install --system -r requirements.txt
         fi
 
-    - name: Uninstall stable pandas
+    - name: Uninstall stable pandas and install nightly pandas
       run: |
         # Uninstall the stable pandas for safety
-        pip uninstall -y pandas
-
-    - name: Install pandas development version (nightly)
-      run: |  
-        # Nightly pandas
+        uv pip uninstall --system pandas
+        # Install the Nightly pandas (may be unstable)
         uv pip install --system -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
 
         # Just a quick check (helpful to search in logs)
         python -c "import pandas as pd; print('Installed pandas version:', pd.__version__)"
 
     - name: Run unit tests with pytest
+      continue-on-error: true # Doesn't fail the check in case some tests fail.
       run: |
-        python -m pytest --cov=nested_pandas
+        # Returns with no error even if the pytest fails some tests
+        python -m pytest || true
+

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -9,6 +9,7 @@
 name: Test against pandas development version
 
 on:
+  pull_request:
   schedule:
     - cron: 45 6 * * *
   workflow_dispatch:
@@ -16,7 +17,6 @@ on:
 jobs:
   test-pandas-dev:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
@@ -50,8 +50,7 @@ jobs:
         python -c "import pandas as pd; print('Installed pandas version:', pd.__version__)"
 
     - name: Run unit tests with pytest
-      continue-on-error: true # Doesn't fail the check in case some tests fail.
+      continue-on-error: true
       run: |
-        # Returns with no error even if the pytest fails some tests
-        python -m pytest || true
+        python -m pytest
 

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -68,3 +68,4 @@ jobs:
         files: pytest-results.xml
         # Differentiates the comments based on the Python version matrix
         check_name: "Pandas Nightly Test Results (Python ${{ matrix.python-version }})"
+        fail_on: "nothing"

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -11,7 +11,7 @@ name: Test against pandas development version
 on:
   pull_request:
   schedule:
-    - cron: '45 6 * * *'
+    - cron: 45 6 * * *
   workflow_dispatch:
 
 jobs:
@@ -53,19 +53,19 @@ jobs:
         uv pip uninstall --system pandas
         uv pip install --system -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
 
+        # Just a quick check (helpful to search in logs)
         python -c "import pandas as pd; print('Installed pandas version:', pd.__version__)"
 
     - name: Run unit tests with pytest
+      continue-on-error: true
       run: |
-        # Run pytest and output the results to an XML file. 
-        # || true ensures the step doesn't crash the workflow if tests fail.
-        python -m pytest --junitxml=pytest-results.xml || true
+        # Runs pytest and exports the report in xml format
+        python -m pytest --junitxml=pytest-results.xml
 
     - name: Publish Test Results as PR Comment
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         files: pytest-results.xml
-        # Differentiates the comments based on the Python version matrix
         check_name: "Pandas Nightly Test Results (Python ${{ matrix.python-version }})"
         fail_on: "nothing"

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -11,7 +11,7 @@ name: Test against pandas development version
 on:
   pull_request:
   schedule:
-    - cron: 45 6 * * *
+    - cron: '45 6 * * *'
   workflow_dispatch:
 
 jobs:
@@ -23,6 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+    
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -52,36 +53,7 @@ jobs:
     - name: Run unit tests with pytest
       continue-on-error: true
       run: |
-        # Run pytest and save the output. Use || true so the step doesn't fail here.
-        python -m pytest > pytest.log || true
-        cat pytest.log
+        uv pip install --system pytest-github-actions-annotate-failures
         
-        # Parse the log and create annotations.json
-        python -c '
-        import json, re
-        
-        annotations = []
-        with open("pytest.log") as f:
-            for line in f:
-                if line.startswith("FAILED ") or line.startswith("ERROR "):
-                    # Extract the file path and error message from the summary line
-                    match = re.search(r"^(?:FAILED|ERROR) (.*?)::(.*?)\s+-\s+(.*)", line)
-                    if match:
-                        annotations.append({
-                            "file": match.group(1).strip(),
-                            "line": 1,
-                            "title": f"Pandas Dev Failure: {match.group(2).strip()}",
-                            "message": match.group(3).strip(),
-                            "annotation_level": "warning"
-                        })
-        
-        with open("annotations.json", "w") as f:
-            json.dump(annotations, f)
-        '
-
-    - name: Annotate failures
-      uses: yuzutech/annotations-action@v0.4.0
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        title: 'Pandas Nightly Tests'
-        input: './annotations.json'
+        # The plugin will automatically hook into pytest and output the annotations
+        python -m pytest

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -52,5 +52,36 @@ jobs:
     - name: Run unit tests with pytest
       continue-on-error: true
       run: |
-        python -m pytest
+        # Run pytest and save the output. Use || true so the step doesn't fail here.
+        python -m pytest > pytest.log || true
+        cat pytest.log
+        
+        # Parse the log and create annotations.json
+        python -c '
+        import json, re
+        
+        annotations = []
+        with open("pytest.log") as f:
+            for line in f:
+                if line.startswith("FAILED ") or line.startswith("ERROR "):
+                    # Extract the file path and error message from the summary line
+                    match = re.search(r"^(?:FAILED|ERROR) (.*?)::(.*?)\s+-\s+(.*)", line)
+                    if match:
+                        annotations.append({
+                            "file": match.group(1).strip(),
+                            "line": 1,
+                            "title": f"Pandas Dev Failure: {match.group(2).strip()}",
+                            "message": match.group(3).strip(),
+                            "annotation_level": "warning"
+                        })
+        
+        with open("annotations.json", "w") as f:
+            json.dump(annotations, f)
+        '
 
+    - name: Annotate failures
+      uses: yuzutech/annotations-action@v0.4.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        title: 'Pandas Nightly Tests'
+        input: './annotations.json'

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -17,6 +17,14 @@ on:
 jobs:
   test-pandas-dev:
     runs-on: ubuntu-latest
+    
+    # Required permissions to allow the bot to post a comment on the PR
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13', '3.14']
@@ -42,18 +50,21 @@ jobs:
 
     - name: Uninstall stable pandas and install nightly pandas
       run: |
-        # Uninstall the stable pandas for safety
         uv pip uninstall --system pandas
-        # Install the Nightly pandas (may be unstable)
         uv pip install --system -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
 
-        # Just a quick check (helpful to search in logs)
         python -c "import pandas as pd; print('Installed pandas version:', pd.__version__)"
 
     - name: Run unit tests with pytest
-      continue-on-error: true
       run: |
-        uv pip install --system pytest-github-actions-annotate-failures
-        
-        # The plugin will automatically hook into pytest and output the annotations
-        python -m pytest
+        # Run pytest and output the results to an XML file. 
+        # || true ensures the step doesn't crash the workflow if tests fail.
+        python -m pytest --junitxml=pytest-results.xml || true
+
+    - name: Publish Test Results as PR Comment
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: pytest-results.xml
+        # Differentiates the comments based on the Python version matrix
+        check_name: "Pandas Nightly Test Results (Python ${{ matrix.python-version }})"

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
 
-    - name: Install dependencie and install pandas nightly
+    - name: Install dependencies
       run: |
         sudo apt-get update
         uv pip install --system -e .[dev]

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -1,0 +1,42 @@
+# This workflow tests against the pandas development version
+# to detect compatibility issues with upcoming pandas releases early.
+#
+# See: https://pandas.pydata.org/docs/getting_started/install.html#installing-the-development-version-of-pandas
+#
+# This job is allowed to fail since pandas dev may introduce breaking changes.
+# Failures here are informational and do not block merges.
+
+name: Test against pandas development version
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-pandas-dev:
+
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        uv pip install --system -e .[dev]
+        pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+    - name: Run unit tests with pytest
+      run: |
+        python -m pytest --cov=nested_pandas

--- a/.github/workflows/testing-pandas-dev.yml
+++ b/.github/workflows/testing-pandas-dev.yml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   test-pandas-dev:
-
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -29,14 +28,31 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
-    - name: Install dependencies
+
+    - name: Install dependencie and install pandas nightly
       run: |
         sudo apt-get update
         uv pip install --system -e .[dev]
-        pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
-        if [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi
+        if [ -f requirements.txt ]; then
+          uv pip install --system -r requirements.txt
+        fi
+
+    - name: Uninstall stable pandas
+      run: |
+        # Uninstall the stable pandas for safety
+        pip uninstall -y pandas
+
+    - name: Install pandas development version (nightly)
+      run: |  
+        # Nightly pandas
+        uv pip install --system -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas
+
+        # Just a quick check (helpful to search in logs)
+        python -c "import pandas as pd; print('Installed pandas version:', pd.__version__)"
+
     - name: Run unit tests with pytest
       run: |
         python -m pytest --cov=nested_pandas


### PR DESCRIPTION
## Change Description
Closes #56 

## Solution Description

Runs a CI job that installs `pandas` latest nightly build (see [installing_dev_branch](https://pandas.pydata.org/docs/getting_started/install.html#installing-the-development-version-of-pandas))  and runs tests to note errors for informational purposes.

Failures during this job won't block merges as it's intended for informational purposes only.

The nightly build is only available for python 3.11, 3.12, 3.13 & 3.14 and is tested against these only (Dropped 3.10). See [PyPI](https://pypi.org/project/pandas/)

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings (tested with local `act`)
- [x] My code contains relevant comments and necessary documentation
