### PR TITLE
Fix generation of unwanted parquet file in doctest

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -2374,7 +2374,7 @@ class NestedFrame(pd.DataFrame):
         --------
         >>> from nested_pandas.datasets.generation import generate_data
         >>> nf = generate_data(5,5, seed=1)
-        >>> nf.to_parquet("nestedframe.parquet")
+        >>> nf.to_parquet("nestedframe.parquet")  # doctest: +SKIP
         """
         df = self.to_pandas(list_struct=False)
 


### PR DESCRIPTION
## Change Description

Closes #467 

## Solution Description

Adds `# doctest: +SKIP` to the function `to_parquet` of the `NestedFrame` class.

This doesn't affect the test itself, it just ignores the test and assumes that it works.

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
