### PR TITLE
Add NestedFrame.split() for splitting nested columns by categorical value

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -879,10 +879,17 @@ class NestedFrame(pd.DataFrame):
                 f"Available sub-columns: {list(self[nested_col].nest.columns)}"
             )
 
-        if len(self) == 0:
-            return self.copy()
+        has_values = values is not None
+        split_values = self[f"{nested_col}.{by}"].unique() if not has_values else list(values)
 
-        split_values = self[f"{nested_col}.{by}"].unique() if values is None else list(values)
+        if len(self) == 0:
+            result = self.copy()
+            if has_values:
+                for val in split_values:
+                    result[f"{nested_col}_{val}"] = None
+            if drop_nested:
+                result = result.drop(labels=[nested_col], axis=1)
+            return result
 
         is_str = pd.api.types.is_string_dtype(self[f"{nested_col}.{by}"])
 
@@ -891,7 +898,9 @@ class NestedFrame(pd.DataFrame):
         for val in split_values:
             val_repr = f"'{val}'" if is_str else val
             queried = self.query(f"{nested_col}.{by}=={val_repr}")
-            if queried is None:
+            if queried is None or len(queried) == 0:
+                if has_values:
+                    result[f"{nested_col}_{val}"] = None
                 continue
             filtered = queried[nested_col]
             if drop_by_col:

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -823,6 +823,86 @@ class NestedFrame(pd.DataFrame):
             errors=errors,
         )
 
+    def split(
+        self,
+        nested_col: str,
+        by: str,
+        values=None,
+        drop_by_col: bool = False,
+        drop_nested: bool = False,
+    ) -> NestedFrame:
+        """Split a nested column into multiple nested columns by a categorical sub-column.
+
+        Parameters
+        ----------
+        nested_col : str
+            The name of the nested column to split.
+        by : str
+            The name of the sub-column within nested_col to split on.
+        values : list or str or None, optional
+            The specific values to split on. If None, all unique values are used.
+            If a string is provided, it is iterated as a list of characters.
+        drop_by_col : bool, default False
+            If True, the sub-column specified by `by` is dropped from each new
+            nested column.
+        drop_nested : bool, default False
+            If True, the original nested column is dropped from the result.
+
+        Returns
+        -------
+        NestedFrame
+            A new NestedFrame with one new nested column per unique value in
+            `by`, named ``{nested_col}_{value}``.
+
+        Examples
+        --------
+        >>> from nested_pandas.datasets.generation import generate_data
+        >>> nf = generate_data(5, 5, seed=1)
+        >>> nf.split("nested", by="band")[["a", "b", "nested_r"]] # doctest: +SKIP
+
+                  a         b                                                  nested_r
+        0  0.417022  0.184677    [{t: 8.38389, flux: 31.551563, band: 'r'}; …] (2 rows)
+        1  0.720324  0.372520   [{t: 19.365232, flux: 90.85955, band: 'r'}; …] (2 rows)
+        2  0.000114  0.691121  [{t: 11.173797, flux: 28.044399, band: 'r'}; …] (3 rows)
+        3  0.302333  0.793535               [{t: 2.807739, flux: 78.927933, band: 'r'}]
+        4  0.146756  1.077633  [{t: 17.527783, flux: 13.002857, band: 'r'}; …] (2 rows)
+        """
+
+        if nested_col not in self.nested_columns:
+            raise ValueError(
+                f"'{nested_col}' is not a nested column. Available nested columns: {self.nested_columns}"
+            )
+
+        if by not in self[nested_col].nest.columns:
+            raise ValueError(
+                f"'{by}' is not a sub-column of '{nested_col}'. "
+                f"Available sub-columns: {list(self[nested_col].nest.columns)}"
+            )
+
+        if len(self) == 0:
+            return self.copy()
+
+        split_values = self[f"{nested_col}.{by}"].unique() if values is None else list(values)
+
+        is_str = pd.api.types.is_string_dtype(self[f"{nested_col}.{by}"])
+
+        result = self.copy()
+
+        for val in split_values:
+            val_repr = f"'{val}'" if is_str else val
+            queried = self.query(f"{nested_col}.{by}=={val_repr}")
+            if queried is None:
+                continue
+            filtered = queried[nested_col]
+            if drop_by_col:
+                filtered = filtered.nest.drop(by)
+            result[f"{nested_col}_{val}"] = filtered
+
+        if drop_nested:
+            result = result.drop(labels=[nested_col], axis=1)
+
+        return result
+
     def min(self, exclude_nest: bool = False, numeric_only: bool = False, **kwargs):
         """
 

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1675,6 +1675,97 @@ def test_drop():
     assert "f" not in dropped_multcols.nested2.nest.columns
 
 
+def test_split():
+    """Test that split correctly splits a nested column by a categorical sub-column"""
+    nf = generate_data(5, 5, seed=1)
+
+    # Test basic split
+    result = nf.split("nested", by="band")
+    assert "nested" in result.columns
+    assert "nested_r" in result.columns
+    assert "nested_g" in result.columns
+    assert isinstance(result["nested_r"].dtype, NestedDtype)
+    assert isinstance(result["nested_g"].dtype, NestedDtype)
+
+    # Test filtering correctness
+    assert (result["nested_r"].nest["band"] == "r").all()
+    assert (result["nested_g"].nest["band"] == "g").all()
+
+    # Test values=None
+    unique_bands = nf["nested.band"].unique()
+    for band in unique_bands:
+        assert f"nested_{band}" in result.columns
+
+    # values= as list subset
+    result_subset = nf.split("nested", by="band", values=["g"])
+    assert "nested_g" in result_subset.columns
+    assert "nested_r" not in result_subset.columns
+
+    # values= as string: iterated as characters
+    result_str = nf.split("nested", by="band", values="rg")
+    assert "nested_r" in result_str.columns
+    assert "nested_g" in result_str.columns
+
+    # values= as empty list
+    result_empty_list = nf.split("nested", by="band", values=[])
+    assert "nested_r" not in result_empty_list.columns
+    assert "nested_g" not in result_empty_list.columns
+    assert "nested" in result_empty_list.columns
+
+    # values= as empty string
+    result_empty_str = nf.split("nested", by="band", values="")
+    assert "nested_r" not in result_empty_str.columns
+    assert "nested_g" not in result_empty_str.columns
+
+    # Test values= with values not present in the data, equivalent to values="z5" or values=["z", "5"]
+    result_missing = nf.split("nested", by="band", values=["z", 5])
+    assert "nested_z" in result_missing.columns
+    assert "nested_5" in result_missing.columns
+    assert result_missing["nested_z"].isna().all()
+    assert result_missing["nested_5"].isna().all()
+
+    # drop_by_col=True
+    result_drop_by = nf.split("nested", by="band", drop_by_col=True)
+    assert "band" not in result_drop_by["nested_r"].nest.columns
+    assert "band" not in result_drop_by["nested_g"].nest.columns
+    assert "t" in result_drop_by["nested_r"].nest.columns
+    assert "flux" in result_drop_by["nested_r"].nest.columns
+
+    # drop_nested=True
+    result_drop_nested = nf.split("nested", by="band", drop_nested=True)
+    assert "nested" not in result_drop_nested.columns
+    assert "nested_r" in result_drop_nested.columns
+    assert "nested_g" in result_drop_nested.columns
+
+    # both drop options together
+    result_drop_both = nf.split("nested", by="band", drop_by_col=True, drop_nested=True)
+    assert "nested" not in result_drop_both.columns
+    assert "band" not in result_drop_both["nested_r"].nest.columns
+
+    # original frame is not modified
+    assert "nested_r" not in nf.columns
+    assert "nested_g" not in nf.columns
+
+
+def test_split_errors():
+    """Test that split raises ValueError for invalid inputs"""
+    nf = generate_data(5, 5, seed=1)
+
+    with pytest.raises(ValueError, match="not a nested column"):
+        nf.split("doesnotexist", by="band")
+
+    with pytest.raises(ValueError, match="not a sub-column"):
+        nf.split("nested", by="doesnotexist")
+
+
+def test_split_empty_frame():
+    """Test that split handles an empty NestedFrame correctly"""
+    nf = generate_data(5, 5, seed=1).iloc[:0]
+    result = nf.split("nested", by="band")
+    assert isinstance(result, NestedFrame)
+    assert len(result) == 0
+
+
 def test_min():
     """Test min function return correct result with and without the nested columns"""
     base = NestedFrame(data={"a": [1, 2, 3], "b": [2, 4, 6], "c": ["x", "y", "z"]}, index=[0, 1, 2])

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -1765,6 +1765,18 @@ def test_split_empty_frame():
     assert isinstance(result, NestedFrame)
     assert len(result) == 0
 
+    # values provided columns must appear as all-NA
+    result_explicit = nf.split("nested", by="band", values=["r", "g"])
+    assert "nested_r" in result_explicit.columns
+    assert "nested_g" in result_explicit.columns
+    assert result_explicit["nested_r"].isna().all()
+    assert result_explicit["nested_g"].isna().all()
+
+    # drop_nested=True must still be honoured on empty frame
+    result_drop = nf.split("nested", by="band", values=["r"], drop_nested=True)
+    assert "nested" not in result_drop.columns
+    assert "nested_r" in result_drop.columns
+
 
 def test_min():
     """Test min function return correct result with and without the nested columns"""


### PR DESCRIPTION

## Change Description

Closes #470

## Solution Description

Adds `NestedFrame.split()` as a `NestedFrame` method rather than `NestedSeries` since `NestedFrame` already handles nested column management and leads to a cleaner workflow.

```python
nf = nf.split("nested", by="band") 
```

### Parameters

- `nested_col`: the nested column to split
- `by`: the sub-column to split on
- `values`: controls which values to split on:
  - `None` (default): uses all unique values found in the column
  - `list` e.g. `values=['r', 'g']` splits on a specific subset only
  - `str` e.g. `values='rg'`: iterated as characters, same as `['r', 'g']`
  - empty list `[]` or empty string `''`: no new columns created
  - values not present in the data: column is created but all-NaN (query matches nothing, no error raised)
- `drop_by_col`: if `True`, removes the splitting sub-column from each new nested column
- `drop_nested`: if `True`, removes the original nested column from the result

### Usage (to be documented)

```python
nf = generate_data(5, 5, seed=1)

# basic split
nf = nf.split("nested", by="band")  # creates nested_r, nested_g

# split on a subset of values only
nf.split("nested", by="band", values=["r"])

# drop the splitting sub-column from each result
nf.split("nested", by="band", drop_by_col=True)

# drop the original nested column after splitting
nf.split("nested", by="band", drop_nested=True)
```

### Tests

Three test functions added to `test_nestedframe.py`:

- `test_split`: covers all behavior: basic split, filtering correctness, all `values=` cases (None, list subset, string as chars, empty list, empty string, missing/mixed-type values), `drop_by_col=True`, `drop_nested=True`, both drop options together, and immutability of the original frame
- `test_split_errors`: covers `ValueError` for invalid `nested_col` and invalid `by` sub-column
- `test_split_empty_frame`: ensures an empty `NestedFrame` is handled correctly and returns an empty `NestedFrame`

## Code Quality

- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
