### PR TITLE
feat: export from_pyarrow as top-level function and add docstring example

### DIFF
--- a/docs/reference/nestedframe.rst
+++ b/docs/reference/nestedframe.rst
@@ -64,3 +64,4 @@ I/O
     NestedFrame.to_parquet
     NestedFrame.to_pandas
     read_parquet
+    from_pyarrow

--- a/src/nested_pandas/__init__.py
+++ b/src/nested_pandas/__init__.py
@@ -1,10 +1,10 @@
 from ._version import __version__
 from .nestedframe import NestedFrame
-from .nestedframe.io import read_parquet
+from .nestedframe.io import read_parquet, from_pyarrow
 
 # Import for registering
 from .series.accessor import NestSeriesAccessor  # noqa: F401
 from .series.dtype import NestedDtype
 from .series.nestedseries import NestedSeries
 
-__all__ = ["NestedDtype", "NestedFrame", "read_parquet", "NestedSeries", "__version__"]
+__all__ = ["NestedDtype", "NestedFrame", "read_parquet", "from_pyarrow", "NestedSeries", "__version__"]

--- a/src/nested_pandas/__init__.py
+++ b/src/nested_pandas/__init__.py
@@ -1,6 +1,6 @@
 from ._version import __version__
 from .nestedframe import NestedFrame
-from .nestedframe.io import read_parquet, from_pyarrow
+from .nestedframe.io import from_pyarrow, read_parquet
 
 # Import for registering
 from .series.accessor import NestSeriesAccessor  # noqa: F401

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -452,8 +452,19 @@ def from_pyarrow(
     --------
     >>> import nested_pandas as npd
     >>> import pyarrow as pa
-    >>> table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    >>> nf = npd.from_pyarrow(table)
+    >>> table = pa.table({
+    ...     "obj_id": [1, 2, 3],
+    ...     "nested": pa.array([
+    ...         [{"time": 1, "flux": 0.5}],
+    ...         [{"time": 2, "flux": 1.2}],
+    ...         [{"time": 3, "flux": 0.8}],
+    ...     ])
+    ... })
+    >>> npd.from_pyarrow(table)
+       obj_id                  nested
+    0       1  [{flux: 0.5, time: 1}]
+    1       2  [{flux: 1.2, time: 2}]
+    2       3  [{flux: 0.8, time: 3}]
 
     """
 

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -448,6 +448,13 @@ def from_pyarrow(
     -------
     NestedFrame
 
+    Examples
+    --------
+    >>> import nested_pandas as npd
+    >>> import pyarrow as pa
+    >>> table = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    >>> nf = npd.from_pyarrow(table)
+
     """
 
     if reject_nesting is None:

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -533,16 +533,16 @@ def from_pyarrow(
     >>> table = pa.table({
     ...     "obj_id": [1, 2, 3],
     ...     "nested": pa.array([
-    ...         [{"time": 1, "flux": 0.5}],
-    ...         [{"time": 2, "flux": 1.2}, {"time": 3, "flux": 0.8}],
-    ...         [{"time": 4, "flux": 2.0}],
+    ...         [{"flux": 0.5, "time": 1}],
+    ...         [{"flux": 1.2, "time": 2}, {"flux": 0.8, "time": 3}],
+    ...         [{"flux": 2.0, "time": 4}],
     ...     ])
     ... })
     >>> npd.from_pyarrow(table)
        obj_id                              nested
-    0       1              [{time: 1, flux: 0.5}]
-    1       2  [{time: 2, flux: 1.2}; …] (2 rows)
-    2       3              [{time: 4, flux: 2.0}]
+    0       1              [{flux: 0.5, time: 1}]
+    1       2  [{flux: 1.2, time: 2}; …] (2 rows)
+    2       3              [{flux: 2.0, time: 4}]
 
     """
 

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -534,15 +534,15 @@ def from_pyarrow(
     ...     "obj_id": [1, 2, 3],
     ...     "nested": pa.array([
     ...         [{"time": 1, "flux": 0.5}],
-    ...         [{"time": 2, "flux": 1.2}],
-    ...         [{"time": 3, "flux": 0.8}],
+    ...         [{"time": 2, "flux": 1.2}, {"time": 3, "flux": 0.8}],
+    ...         [{"time": 4, "flux": 2.0}],
     ...     ])
     ... })
     >>> npd.from_pyarrow(table)
-       obj_id                  nested
-    0       1  [{flux: 0.5, time: 1}]
-    1       2  [{flux: 1.2, time: 2}]
-    2       3  [{flux: 0.8, time: 3}]
+       obj_id                              nested
+    0       1              [{time: 1, flux: 0.5}]
+    1       2  [{time: 2, flux: 1.2}; …] (2 rows)
+    2       3              [{time: 4, flux: 2.0}]
 
     """
 


### PR DESCRIPTION
Fixes #432

## Changes
- Added `from_pyarrow` to the top-level `__init__.py` imports so it can be used as `npd.from_pyarrow()`
- Added `from_pyarrow` to `__all__`
- Added a docstring example to `from_pyarrow` in `io.py`

## Testing
All 412 existing tests pass with no failures.