### PR TITLE
Chunking and rechunking functionality for large datasets

### DIFF
--- a/src/nested_pandas/series/accessor.py
+++ b/src/nested_pandas/series/accessor.py
@@ -171,7 +171,7 @@ class NestSeriesAccessor(Mapping):
     @property
     def flat_index(self) -> pd.Index:
         """Index of the flattened arrays"""
-        flat_index = np.repeat(self._series.index, np.diff(self._series.array.list_offsets))
+        flat_index = np.repeat(self._series.index, self._series.array.list_lengths)
         # pd.Index supports np.repeat, so flat_index is the same type as self._series.index
         flat_index = cast(pd.Index, flat_index)
         return flat_index

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -65,6 +65,7 @@ from nested_pandas.series.nestedseries import NestedSeries  # noqa
 from nested_pandas.series.utils import (
     _MAX_FLAT_SIZE,
     chunk_lengths,
+    chunk_sizes_are_fragmented,
     compute_chunk_boundaries,
     is_pa_type_a_list,
     normalize_list_array,
@@ -677,12 +678,6 @@ class NestedExtensionArray(ExtensionArray):
 
         return array
 
-    # Adopted from ArrowExtensionArray
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state["_storage"] = ListStructStorage(self.list_array.combine_chunks())
-        return state
-
     # End of Additional magic methods #
 
     @classmethod
@@ -1048,27 +1043,8 @@ class NestedExtensionArray(ExtensionArray):
         """
         if min_chunk_size is None:
             min_chunk_size = DEFAULT_MIN_CHUNK_SIZE
-
-        chunks = list(self.list_array.iterchunks())
-
-        # Find where the trailing run of small chunks ("tail") begins.
-        # Scan right-to-left: stop at the first chunk that is large enough.
-        tail_start = len(chunks)
-        tail_rows = 0
-        for i in range(len(chunks) - 1, -1, -1):
-            if len(chunks[i]) >= min_chunk_size:
-                break
-            tail_start = i
-            tail_rows += len(chunks[i])
-
-        # Every "body" chunk (before the tail) must be full-size.
-        for chunk in chunks[:tail_start]:
-            if len(chunk) < min_chunk_size:
-                return True
-
-        # The tail is acceptable while its total row count is below min_chunk_size.
-        # Once the tail could form a proper chunk it is worth consolidating.
-        return tail_rows >= min_chunk_size
+        sizes = [len(c) for c in self.list_array.iterchunks()]
+        return chunk_sizes_are_fragmented(sizes, min_chunk_size)
 
     def _chunk_boundaries(self, chunk_size: int) -> list[int]:
         """Compute chunk boundaries for this array.

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -602,7 +602,10 @@ class NestedExtensionArray(ExtensionArray):
     def _concat_same_type(cls, to_concat: Sequence[Self]) -> Self:  # type: ignore[name-defined] # noqa: F821
         chunks = [chunk for ext_array in to_concat for chunk in ext_array.list_array.iterchunks()]
         pa_array = pa.chunked_array(chunks)
-        return cls(pa_array)
+        result = cls(pa_array)
+        if result.is_fragmented():
+            return result.rechunk()
+        return result
 
     def equals(self, other) -> bool:
         """

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -64,6 +64,7 @@ from nested_pandas.series.dtype import NestedDtype
 from nested_pandas.series.nestedseries import NestedSeries  # noqa
 from nested_pandas.series.utils import (
     chunk_lengths,
+    compute_chunk_boundaries,
     is_pa_type_a_list,
     normalize_list_array,
     normalize_struct_list_type,
@@ -73,6 +74,12 @@ from nested_pandas.series.utils import (
 )
 
 __all__ = ["NestedExtensionArray"]
+
+DEFAULT_CHUNK_SIZE = 1_048_576
+"""Target number of outer rows per chunk for :meth:`NestedExtensionArray.rechunk`.
+
+Matches PyArrow's default Parquet row group size.
+"""
 
 
 BOXED_NESTED_EXTENSION_ARRAY_FORMAT_TRICK = True
@@ -1005,6 +1012,41 @@ class NestedExtensionArray(ExtensionArray):
         """Number of chunk_lens in underlying pyarrow.ChunkedArray"""
         return self._storage.num_chunks
 
+    def rechunk(self, chunk_size: int | None = None) -> NestedExtensionArray:  # type: ignore[name-defined] # noqa: F821
+        """Rechunk the array to approximately ``chunk_size`` outer rows per chunk.
+
+        Parameters
+        ----------
+        chunk_size : int or None
+            Target number of outer rows per chunk.  If ``None``, uses
+            ``DEFAULT_CHUNK_SIZE`` (PyArrow's default Parquet row group size,
+            1_048_576).  Chunks may be smaller when the flat (inner) row count
+            would overflow int32 offsets (see ``_MAX_FLAT_SIZE``).
+
+        Returns
+        -------
+        NestedExtensionArray
+            A new array with rebalanced chunks.
+        """
+        if chunk_size is None:
+            chunk_size = DEFAULT_CHUNK_SIZE
+        if chunk_size < 1:
+            raise ValueError("chunk_size must be >= 1")
+
+        list_lengths = self.list_lengths
+        boundaries = compute_chunk_boundaries(list_lengths, chunk_size)
+
+        combined = self.list_array
+        chunks = []
+        start = 0
+        for end in boundaries:
+            # combine_chunks() slices combined[start:end] into a fresh ListArray
+            # with zero-based offsets, guaranteeing no int32 overflow.
+            chunk = combined[start:end].combine_chunks()
+            chunks.append(chunk)
+            start = end
+        return type(self)(pa.chunked_array(chunks, type=combined.type))
+
     def get_list_index(self) -> np.ndarray:
         """Keys mapping values to lists"""
         if len(self) == 0:
@@ -1102,11 +1144,47 @@ class NestedExtensionArray(ExtensionArray):
         if len(pa_array) != self.flat_length:
             raise ValueError("The input must be a struct_scalar or have the same length as the flat arrays")
 
-        if isinstance(pa_array, pa.ChunkedArray):
-            pa_array = pa_array.combine_chunks()
-        field_list_array = pa.ListArray.from_arrays(values=pa_array, offsets=self.list_offsets)
+        # Convert flat input to ChunkedArray for uniform handling
+        flat_chunked = pa.chunked_array([pa_array]) if isinstance(pa_array, pa.Array) else pa_array
 
-        return self.set_list_field(field, field_list_array, keep_dtype=keep_dtype)
+        # Build one ListArray per outer chunk, slicing the flat input accordingly.
+        # This avoids a global combine_chunks() of the flat array and a global
+        # list_offsets computation.
+        list_chunks = []
+        flat_offset = 0
+        for outer_chunk in self.list_array.iterchunks():
+            outer_chunk = cast(pa.ListArray, outer_chunk)
+            offsets = outer_chunk.offsets
+            flat_start = offsets[0].as_py()
+            flat_end = offsets[-1].as_py()
+            chunk_flat_size = flat_end - flat_start
+
+            flat_slice_chunked = flat_chunked[flat_offset : flat_offset + chunk_flat_size]
+            # Avoid an unnecessary copy when the slice already lands on a single
+            # contiguous chunk (the common path when both self and pa_array are
+            # single-chunk arrays).
+            if flat_slice_chunked.num_chunks == 1:
+                flat_slice = flat_slice_chunked.chunk(0)
+            else:
+                flat_slice = flat_slice_chunked.combine_chunks()
+            flat_offset += chunk_flat_size
+
+            # Normalize offsets to start at 0 (required when outer_chunk is a view
+            # with non-zero offsets[0] pointing into a larger flat buffer)
+            chunk_offsets = pa.compute.subtract(offsets, offsets[0]) if flat_start != 0 else offsets
+
+            list_chunks.append(pa.ListArray.from_arrays(offsets=chunk_offsets, values=flat_slice))
+
+        new_list_array = pa.chunked_array(list_chunks, type=pa.list_(pa_array.type))
+
+        # Update the table directly — set_list_field would call pa.array(value, ...)
+        # which does not handle ChunkedArray inputs reliably.
+        if field in self.field_names:
+            field_idx = self.field_names.index(field)
+            pa_table = self.pa_table.drop(field).add_column(field_idx, field, new_list_array)
+        else:
+            pa_table = self.pa_table.append_column(field, new_list_array)
+        self.pa_table = pa_table
 
     def set_list_field(self, field: str, value: ArrayLike, *, keep_dtype: bool = False) -> None:
         """Set the field from list-array

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -318,13 +318,13 @@ class NestedExtensionArray(ExtensionArray):
                 return type(self)(pa.chunked_array([], type=self.dtype.pyarrow_dtype), validate=False)
             pa_item = pa.array(item)
             if item.dtype.kind in "iu":
-                return type(self)(self.struct_array.take(pa_item), validate=False)
-            if item.dtype.kind == "b":
-                return type(self)(self.struct_array.filter(pa_item), validate=False)
-            # It should be covered by check_array_indexer above
-            raise IndexError(
-                "Only integers, slices and integer or boolean arrays are valid indices."
-            )  # pragma: no cover
+                pa_item = self.struct_array.take(pa_item)
+            elif item.dtype.kind == "b":
+                pa_item = self.struct_array.filter(pa_item)
+            else:  # pragma: no cover
+                raise IndexError("Only integers, slices and integer or boolean arrays are valid indices.")
+            result = type(self)(pa_item, validate=False)
+            return result._rechunk_if_fragmented()
 
         if isinstance(item, tuple):
             item = unpack_tuple_and_ellipses(item)
@@ -337,7 +337,8 @@ class NestedExtensionArray(ExtensionArray):
             return self._convert_struct_scalar_to_df(scalar_or_array, copy=False)
         # Logically, it must be a pa.ChunkedArray if it is not a scalar
         pa_array = cast(pa.ChunkedArray, scalar_or_array)
-        return type(self)(pa_array, validate=False)
+        result = type(self)(pa_array, validate=False)
+        return result._rechunk_if_fragmented()
 
     def __setitem__(self, key, value) -> None:
         # TODO: optimize for many chunk_lens
@@ -544,22 +545,28 @@ class NestedExtensionArray(ExtensionArray):
             fill_mask = indices_array < 0
             if not fill_mask.any():
                 # Nothing to fill, using list-array should be faster
-                return type(self)(self.list_array.take(indices))
+                result = type(self)(self.list_array.take(indices))
+                return result._rechunk_if_fragmented()
             validate_indices(indices_array, len(self))
             indices_array = pa.array(indices_array, mask=fill_mask)
 
-            result = self.struct_array.take(indices_array)
+            taken = self.struct_array.take(indices_array)
             if not pa.compute.is_null(fill_value).as_py():
-                result = pa.compute.if_else(fill_mask, fill_value, result)
+                taken = pa.compute.if_else(fill_mask, fill_value, taken)
             # Validate for fill_value
-            return type(self)(result, validate=True)
+            result = type(self)(taken, validate=True)
+            return result._rechunk_if_fragmented()
 
         if (indices_array < 0).any():
             # Don't modify in-place
             indices_array = np.copy(indices_array)
             indices_array[indices_array < 0] += len(self)
         # list_array should be faster
-        return type(self)(self.list_array.take(indices_array))
+        result = type(self)(self.list_array.take(indices_array))
+        return result._rechunk_if_fragmented()
+
+    def _rechunk_if_fragmented(self) -> Self:  # type: ignore[name-defined] # noqa: F821
+        return self.rechunk() if self.is_fragmented() else self
 
     def copy(self) -> Self:  # type: ignore[name-defined] # noqa: F821
         """Return a copy of the extension array.
@@ -973,17 +980,22 @@ class NestedExtensionArray(ExtensionArray):
 
         Returns
         -------
-        pa.ChunkedArray
-            The list offsets of the field arrays.
+        pa.Array
+            Cumulative offsets of length ``len(self) + 1``.  For a single-chunk
+            array the dtype is ``int32`` (matching the underlying
+            ``pa.ListArray`` buffer).  For a multi-chunk array the dtype is
+            ``int64`` to avoid silent overflow when the total number of flat
+            rows exceeds ``2**31``.
         """
         # Cheap path for a single chunk
         if self._storage.num_chunks == 1:
             return self.list_array.chunk(0).offsets
 
+        # Use int64 to avoid overflow when total flat rows exceed 2^31.
         zero_and_lengths = pa.chunked_array(
             [
-                pa.array([0], type=pa.int32()),
-                pa.array(self.list_lengths, type=pa.int32()),
+                pa.array([0], type=pa.int64()),
+                pa.array(self.list_lengths, type=pa.int64()),
             ]
         )
         offsets = pa.compute.cumulative_sum(zero_and_lengths)

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -63,6 +63,7 @@ from nested_pandas.series._storage import (
 from nested_pandas.series.dtype import NestedDtype
 from nested_pandas.series.nestedseries import NestedSeries  # noqa
 from nested_pandas.series.utils import (
+    _MAX_FLAT_SIZE,
     chunk_lengths,
     compute_chunk_boundaries,
     is_pa_type_a_list,
@@ -80,6 +81,9 @@ DEFAULT_CHUNK_SIZE = 1_048_576
 
 Matches PyArrow's default Parquet row group size.
 """
+
+DEFAULT_MIN_CHUNK_SIZE = 4_096
+"""Minimum outer rows per chunk before :meth:`NestedExtensionArray.is_fragmented` flags excess chunks."""
 
 
 BOXED_NESTED_EXTENSION_ARRAY_FORMAT_TRICK = True
@@ -1012,6 +1016,70 @@ class NestedExtensionArray(ExtensionArray):
         """Number of chunk_lens in underlying pyarrow.ChunkedArray"""
         return self._storage.num_chunks
 
+    def is_fragmented(
+        self,
+        min_chunk_size: int | None = None,
+    ) -> bool:
+        """Check whether :meth:`rechunk` would improve memory layout.
+
+        Returns ``True`` if any of the following hold:
+
+        - Any "body" chunk (all chunks except a trailing run of small ones)
+          has fewer than ``min_chunk_size`` outer rows.
+        - The trailing run of small chunks ("tail") has accumulated enough
+          rows in total to form a proper chunk (i.e. total >= ``min_chunk_size``).
+
+        The tail allowance amortises detection cost for incremental-append
+        workloads: a rechunk is triggered roughly once per ``min_chunk_size``
+        single-row appends rather than after every second append.
+
+        Parameters
+        ----------
+        min_chunk_size : int or None
+            Minimum acceptable average outer rows per chunk.
+            Defaults to ``DEFAULT_MIN_CHUNK_SIZE`` (1_024).
+
+        Returns
+        -------
+        bool
+        """
+        if min_chunk_size is None:
+            min_chunk_size = DEFAULT_MIN_CHUNK_SIZE
+
+        chunks = list(self.list_array.iterchunks())
+
+        # Find where the trailing run of small chunks ("tail") begins.
+        # Scan right-to-left: stop at the first chunk that is large enough.
+        tail_start = len(chunks)
+        tail_rows = 0
+        for i in range(len(chunks) - 1, -1, -1):
+            if len(chunks[i]) >= min_chunk_size:
+                break
+            tail_start = i
+            tail_rows += len(chunks[i])
+
+        # Every "body" chunk (before the tail) must be full-size.
+        for chunk in chunks[:tail_start]:
+            if len(chunk) < min_chunk_size:
+                return True
+
+        # The tail is acceptable while its total row count is below min_chunk_size.
+        # Once the tail could form a proper chunk it is worth consolidating.
+        return tail_rows >= min_chunk_size
+
+    def _chunk_boundaries(self, chunk_size: int) -> list[int]:
+        """Compute chunk boundaries for this array.
+
+        Uses the total flat size from chunk metadata (O(n_chunks)) to avoid
+        computing list_lengths when there is no int32 overflow risk.
+        """
+        n = len(self)
+        total_flat = sum(len(chunk.values) for chunk in self.list_array.chunks)
+        if total_flat <= _MAX_FLAT_SIZE:
+            # No overflow risk: boundaries are pure arithmetic, no need to compute list_lengths.
+            return list(range(0, n, chunk_size)) + [n]
+        return compute_chunk_boundaries(self.list_lengths, chunk_size)
+
     def rechunk(self, chunk_size: int | None = None) -> NestedExtensionArray:  # type: ignore[name-defined] # noqa: F821
         """Rechunk the array to approximately ``chunk_size`` outer rows per chunk.
 
@@ -1026,25 +1094,29 @@ class NestedExtensionArray(ExtensionArray):
         Returns
         -------
         NestedExtensionArray
-            A new array with rebalanced chunks.
+            A new array with rebalanced chunks, or ``self`` if already clean.
         """
         if chunk_size is None:
             chunk_size = DEFAULT_CHUNK_SIZE
         if chunk_size < 1:
             raise ValueError("chunk_size must be >= 1")
 
-        list_lengths = self.list_lengths
-        boundaries = compute_chunk_boundaries(list_lengths, chunk_size)
+        boundaries = self._chunk_boundaries(chunk_size)
+
+        # Fast-path: already in the exact layout rechunk would produce.
+        # Build expected sizes from boundaries and compare to current chunk sizes.
+        expected_sizes = [boundaries[i + 1] - boundaries[i] for i in range(len(boundaries) - 1)]
+        actual_sizes = [len(c) for c in self.list_array.iterchunks()]
+        if actual_sizes == expected_sizes:
+            return self
 
         combined = self.list_array
-        chunks = []
-        start = 0
-        for end in boundaries:
+        chunks = [
             # combine_chunks() slices combined[start:end] into a fresh ListArray
             # with zero-based offsets, guaranteeing no int32 overflow.
-            chunk = combined[start:end].combine_chunks()
-            chunks.append(chunk)
-            start = end
+            combined[start:end].combine_chunks()
+            for start, end in zip(boundaries[:-1], boundaries[1:], strict=True)
+        ]
         return type(self)(pa.chunked_array(chunks, type=combined.type))
 
     def get_list_index(self) -> np.ndarray:

--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -14,8 +14,9 @@ import pandas as pd
 import pyarrow as pa
 
 from nested_pandas.series.dtype import NestedDtype
-from nested_pandas.series.ext_array import NestedExtensionArray
+from nested_pandas.series.ext_array import DEFAULT_CHUNK_SIZE, DEFAULT_MIN_CHUNK_SIZE, NestedExtensionArray
 from nested_pandas.series.nestedseries import NestedSeries
+from nested_pandas.series.utils import chunk_sizes_are_fragmented, compute_chunk_boundaries
 from nested_pandas.series.utils import rechunk as rechunk_array
 
 __all__ = ["pack", "pack_flat", "pack_lists", "pack_seq"]
@@ -224,39 +225,50 @@ def pack_lists(df: pd.DataFrame, name: str | None = None, *, validate: bool = Tr
         for column, arr in pa_arrays_maybe_chunked.items()
     }
 
-    # If all chunk arrays have the same chunk lengths, we can build a chunked struct array with no
-    # data copying.
-    chunk_lengths = pa.array([[len(chunk) for chunk in arr.chunks] for arr in pa_chunked_arrays.values()])
-    if all(chunk_length == chunk_lengths[0] for chunk_length in chunk_lengths):
-        chunks = []
-        num_chunks = next(iter(pa_chunked_arrays.values())).num_chunks
-        for i in range(num_chunks):
-            chunks.append(
-                pa.StructArray.from_arrays(
-                    [arr.chunk(i) for arr in pa_chunked_arrays.values()],
-                    names=pa_chunked_arrays.keys(),
-                )
-            )
-        struct_array = pa.chunked_array(chunks)
-    else:
-        # Rechunk all columns to match the column with the fewest chunks.
-        # This minimises combine_chunks() calls on other columns and produces
-        # the coarsest output chunk structure, which is better for downstream ops.
-        reference = min(pa_chunked_arrays.values(), key=lambda a: a.num_chunks)
-        ref_chunk_lens = [len(c) for c in reference.iterchunks()]
-        aligned = {col: rechunk_array(arr, ref_chunk_lens) for col, arr in pa_chunked_arrays.items()}
-        num_chunks = reference.num_chunks
-        struct_chunks = []
-        for i in range(num_chunks):
-            struct_chunks.append(
-                pa.StructArray.from_arrays(
-                    [aligned[col].chunk(i) for col in aligned],
-                    names=list(aligned.keys()),
-                )
-            )
-        struct_array = pa.chunked_array(struct_chunks)
+    first_col = next(iter(pa_chunked_arrays.values()))
+    first_sizes = [len(c) for c in first_col.chunks]
+    all_aligned = all([len(c) for c in arr.chunks] == first_sizes for arr in pa_chunked_arrays.values())
+    struct_type = pa.struct([pa.field(col, arr.type) for col, arr in pa_chunked_arrays.items()])
 
-    ext_array = NestedExtensionArray(struct_array, validate=validate)
+    if all_aligned and not chunk_sizes_are_fragmented(first_sizes, DEFAULT_MIN_CHUNK_SIZE):
+        # All columns share the same non-fragmented chunk layout — build struct with no data copying.
+        struct_chunks = [
+            pa.StructArray.from_arrays(
+                [arr.chunk(i) for arr in pa_chunked_arrays.values()],
+                names=list(pa_chunked_arrays.keys()),
+            )
+            for i in range(first_col.num_chunks)
+        ]
+        struct_array = pa.chunked_array(struct_chunks, type=struct_type)
+        ext_array = NestedExtensionArray(struct_array, validate=validate)
+    elif all_aligned:
+        # Aligned but fragmented — building struct from aligned columns is cheap (no copying),
+        # then rechunk the struct to merge small chunks.
+        struct_chunks = [
+            pa.StructArray.from_arrays(
+                [arr.chunk(i) for arr in pa_chunked_arrays.values()],
+                names=list(pa_chunked_arrays.keys()),
+            )
+            for i in range(first_col.num_chunks)
+        ]
+        struct_array = pa.chunked_array(struct_chunks, type=struct_type)
+        ext_array = NestedExtensionArray(struct_array, validate=validate).rechunk()
+    else:
+        # Misaligned chunks — rechunk all columns to DEFAULT_CHUNK_SIZE boundaries first,
+        # then build struct. This avoids building a misaligned struct and a second rechunk.
+        n = len(df)
+        full, rem = divmod(n, DEFAULT_CHUNK_SIZE)
+        target_sizes = [DEFAULT_CHUNK_SIZE] * full + ([rem] if rem else [])
+        aligned = {col: rechunk_array(arr, target_sizes) for col, arr in pa_chunked_arrays.items()}
+        struct_chunks = [
+            pa.StructArray.from_arrays(
+                [aligned[col].chunk(i) for col in aligned],
+                names=list(aligned.keys()),
+            )
+            for i in range(len(target_sizes))
+        ]
+        struct_array = pa.chunked_array(struct_chunks)
+        ext_array = NestedExtensionArray(struct_array, validate=validate)
     return NestedSeries(
         ext_array,
         index=df.index,
@@ -284,9 +296,12 @@ def view_sorted_df_as_list_arrays(df: pd.DataFrame) -> pd.DataFrame:
 
     offset_array = calculate_sorted_index_offsets(df.index)
     unique_index = df.index[offset_array[:-1]]
+    boundaries = compute_chunk_boundaries(np.diff(offset_array), DEFAULT_CHUNK_SIZE)
 
     series_ = {
-        column: view_sorted_series_as_list_array(df[column], offset_array, unique_index)
+        column: view_sorted_series_as_list_array(
+            df[column], offset=offset_array, boundaries=boundaries, unique_index=unique_index
+        )
         for column in df.columns
     }
 
@@ -297,7 +312,9 @@ def view_sorted_df_as_list_arrays(df: pd.DataFrame) -> pd.DataFrame:
 
 def view_sorted_series_as_list_array(
     series: NestedSeries,
+    *,
     offset: np.ndarray | None = None,
+    boundaries: list[int] | None = None,
     unique_index: np.ndarray | None = None,
 ) -> NestedSeries:
     """Make a nested array representation of a "flat" series.
@@ -308,7 +325,12 @@ def view_sorted_series_as_list_array(
         Input series, with repeated indexes. It must be sorted by its index.
 
     offset: np.ndarray or None, optional
-        Pre-calculated offsets of the input series index.
+        Pre-calculated int64 offsets of the input series index.
+    boundaries: list[int] or None, optional
+        Pre-calculated chunk boundaries from ``compute_chunk_boundaries``.
+        If given, ``offset`` must also be provided. Passing this avoids
+        recomputing boundaries when processing multiple columns that share
+        the same offset array.
     unique_index: np.ndarray or None, optional
         Pre-calculated unique index of the input series. If given it must be
         equal to `series.index.unique()` and `series.index.values[offset[:-1]]`.
@@ -326,6 +348,8 @@ def view_sorted_series_as_list_array(
         offset = calculate_sorted_index_offsets(series.index)
     if unique_index is None:
         unique_index = series.index[offset[:-1]]
+    if boundaries is None:
+        boundaries = compute_chunk_boundaries(np.diff(offset), DEFAULT_CHUNK_SIZE)
 
     # Input series may be represented by pyarrow.ChunkedArray, in this case pa.array(series) would fail
     # with "TypeError: Cannot convert a 'ChunkedArray' to a 'ListArray'".
@@ -333,14 +357,23 @@ def view_sorted_series_as_list_array(
     flat_array = pa.array(series, from_pandas=True)
     if isinstance(flat_array, pa.ChunkedArray):
         flat_array = flat_array.combine_chunks()
-    list_array = pa.ListArray.from_arrays(
-        offset,
-        flat_array,
-    )
+
+    # Split into chunks so each ListArray fits within int32 offset limits and
+    # aligns with DEFAULT_CHUNK_SIZE. Since all columns in a DataFrame share
+    # the same offset array, they produce identical boundaries and are aligned,
+    # which lets pack_lists take the zero-copy aligned path.
+    list_chunks = [
+        pa.ListArray.from_arrays(
+            offsets=(offset[b_start : b_end + 1] - offset[b_start]).astype(np.int32),
+            values=flat_array[int(offset[b_start]) : int(offset[b_end])],
+        )
+        for b_start, b_end in zip(boundaries[:-1], boundaries[1:], strict=True)
+    ]
+    chunked_list_array = pa.chunked_array(list_chunks, type=pa.list_(flat_array.type))
 
     return NestedSeries(
-        list_array,
-        dtype=pd.ArrowDtype(list_array.type),
+        chunked_list_array,
+        dtype=pd.ArrowDtype(chunked_list_array.type),
         index=unique_index,
         copy=False,
         name=series.name,
@@ -358,8 +391,10 @@ def calculate_sorted_index_offsets(index: pd.Index) -> np.ndarray:
     Returns
     -------
     np.ndarray
-        Output array of offsets, one element more than the number of unique
-        index values.
+        Output array of int64 offsets, one element more than the number of
+        unique index values. int64 is used to avoid overflow for large flat
+        arrays; callers that build ``pa.ListArray`` chunks must cast each
+        per-chunk slice to int32 after normalising to zero.
     """
     if not index.is_monotonic_increasing:
         raise ValueError("The index must be sorted")
@@ -369,7 +404,4 @@ def calculate_sorted_index_offsets(index: pd.Index) -> np.ndarray:
     offset_but_last = np.nonzero(~index.duplicated(keep="first"))[0]
     offset = np.append(offset_but_last, len(index))
 
-    # Arrow uses int32 for offsets
-    offset = offset.astype(np.int32)
-
-    return offset
+    return offset.astype(np.int64)

--- a/src/nested_pandas/series/packer.py
+++ b/src/nested_pandas/series/packer.py
@@ -16,6 +16,7 @@ import pyarrow as pa
 from nested_pandas.series.dtype import NestedDtype
 from nested_pandas.series.ext_array import NestedExtensionArray
 from nested_pandas.series.nestedseries import NestedSeries
+from nested_pandas.series.utils import rechunk as rechunk_array
 
 __all__ = ["pack", "pack_flat", "pack_lists", "pack_seq"]
 
@@ -237,11 +238,23 @@ def pack_lists(df: pd.DataFrame, name: str | None = None, *, validate: bool = Tr
                 )
             )
         struct_array = pa.chunked_array(chunks)
-    else:  # "flatten" the chunked arrays
-        struct_array = pa.StructArray.from_arrays(
-            [arr.combine_chunks() for arr in pa_chunked_arrays.values()],
-            names=pa_chunked_arrays.keys(),
-        )
+    else:
+        # Rechunk all columns to match the column with the fewest chunks.
+        # This minimises combine_chunks() calls on other columns and produces
+        # the coarsest output chunk structure, which is better for downstream ops.
+        reference = min(pa_chunked_arrays.values(), key=lambda a: a.num_chunks)
+        ref_chunk_lens = [len(c) for c in reference.iterchunks()]
+        aligned = {col: rechunk_array(arr, ref_chunk_lens) for col, arr in pa_chunked_arrays.items()}
+        num_chunks = reference.num_chunks
+        struct_chunks = []
+        for i in range(num_chunks):
+            struct_chunks.append(
+                pa.StructArray.from_arrays(
+                    [aligned[col].chunk(i) for col in aligned],
+                    names=list(aligned.keys()),
+                )
+            )
+        struct_array = pa.chunked_array(struct_chunks)
 
     ext_array = NestedExtensionArray(struct_array, validate=validate)
     return NestedSeries(

--- a/src/nested_pandas/series/utils.py
+++ b/src/nested_pandas/series/utils.py
@@ -444,6 +444,64 @@ def rechunk(array: pa.Array | pa.ChunkedArray, chunk_lens: ArrayLike) -> pa.Chun
     return pa.chunked_array(chunks)
 
 
+_MAX_FLAT_SIZE = 2**31 - 2
+"""Maximum flat (inner) row count per chunk.
+
+``pa.ListArray`` uses int32 offsets, so a single chunk cannot reference more
+flat values than int32 can hold.  This constant is the upper bound used by
+``compute_chunk_boundaries`` to split chunks before overflow.
+"""
+
+
+def compute_chunk_boundaries(list_lengths: np.ndarray, chunk_size: int) -> list[int]:
+    """Compute chunk boundary indices from list lengths.
+
+    Returns a list of end indices (exclusive) for each chunk, such that:
+
+    - each chunk has at most ``chunk_size`` outer rows
+    - cumulative flat (inner) row count per chunk does not exceed
+      ``_MAX_FLAT_SIZE`` (2**31 - 2), which is the maximum safe value for
+      ``pa.ListArray`` int32 offsets
+
+    Parameters
+    ----------
+    list_lengths : np.ndarray
+        Array of list lengths (number of inner elements per outer row).
+    chunk_size : int
+        Target number of outer rows per chunk.
+
+    Returns
+    -------
+    list[int]
+        End indices (exclusive) for each chunk.
+    """
+    n = len(list_lengths)
+    if n == 0:
+        return []
+
+    # O(n) one-time cumulative sum; use int64 to avoid overflow during computation
+    cumflat_ext = np.empty(n + 1, dtype=np.int64)
+    cumflat_ext[0] = 0
+    cumflat_ext[1:] = np.cumsum(list_lengths.astype(np.int64))
+
+    boundaries = []
+    start = 0
+    while start < n:
+        row_end = min(start + chunk_size, n)
+        flat_limit = cumflat_ext[start] + _MAX_FLAT_SIZE
+
+        # Binary search: find the last end s.t. per-chunk flat count <= _MAX_FLAT_SIZE.
+        # searchsorted 'right' gives first idx where cumflat_ext[idx] > flat_limit,
+        # so the last valid exclusive end is idx - 1.
+        idx = int(np.searchsorted(cumflat_ext, flat_limit, side="right"))
+        flat_end = min(idx - 1, row_end)
+        end = max(flat_end, start + 1)  # always advance at least one row
+
+        boundaries.append(end)
+        start = end
+    return boundaries
+
+
 def normalize_list_array(
     array: pa.ListArray | pa.FixedSizeListArray | pa.LargeListArray | pa.ChunkedArray,
 ) -> pa.ListArray | pa.ChunkedArray:

--- a/src/nested_pandas/series/utils.py
+++ b/src/nested_pandas/series/utils.py
@@ -411,6 +411,25 @@ def chunk_lengths(array: pa.ChunkedArray) -> list[int]:
     return [len(chunk) for chunk in array.iterchunks()]
 
 
+def chunk_sizes_are_fragmented(sizes: list[int], min_chunk_size: int) -> bool:
+    """Return True if the given chunk sizes represent a fragmented layout.
+
+    Mirrors the logic of ``NestedExtensionArray.is_fragmented`` but operates
+    directly on a list of chunk sizes, avoiding the need to construct an array.
+    """
+    tail_start = len(sizes)
+    tail_rows = 0
+    for i in range(len(sizes) - 1, -1, -1):
+        if sizes[i] >= min_chunk_size:
+            break
+        tail_start = i
+        tail_rows += sizes[i]
+    for size in sizes[:tail_start]:
+        if size < min_chunk_size:
+            return True
+    return tail_rows >= min_chunk_size
+
+
 def rechunk(array: pa.Array | pa.ChunkedArray, chunk_lens: ArrayLike) -> pa.ChunkedArray:
     """Rechunk array to the same chunks a given chunked array.
 

--- a/src/nested_pandas/series/utils.py
+++ b/src/nested_pandas/series/utils.py
@@ -456,12 +456,13 @@ flat values than int32 can hold.  This constant is the upper bound used by
 def compute_chunk_boundaries(list_lengths: np.ndarray, chunk_size: int) -> list[int]:
     """Compute chunk boundary indices from list lengths.
 
-    Returns a list of end indices (exclusive) for each chunk, such that:
+    Returns offsets in Arrow style: ``[0, end0, end1, ..., n]``, so that
+    chunk ``i`` spans rows ``boundaries[i] : boundaries[i+1]``.  Each chunk
+    satisfies:
 
-    - each chunk has at most ``chunk_size`` outer rows
-    - cumulative flat (inner) row count per chunk does not exceed
-      ``_MAX_FLAT_SIZE`` (2**31 - 2), which is the maximum safe value for
-      ``pa.ListArray`` int32 offsets
+    - at most ``chunk_size`` outer rows
+    - cumulative flat (inner) row count does not exceed ``_MAX_FLAT_SIZE``
+      (2**31 - 2), the maximum safe value for ``pa.ListArray`` int32 offsets
 
     Parameters
     ----------
@@ -473,18 +474,19 @@ def compute_chunk_boundaries(list_lengths: np.ndarray, chunk_size: int) -> list[
     Returns
     -------
     list[int]
-        End indices (exclusive) for each chunk.
+        Offsets array ``[0, end0, end1, ..., n]`` with ``len(boundaries) - 1``
+        chunks.  Returns ``[0]`` (no chunks) when ``list_lengths`` is empty.
     """
     n = len(list_lengths)
     if n == 0:
-        return []
+        return [0]
 
     # O(n) one-time cumulative sum; use int64 to avoid overflow during computation
     cumflat_ext = np.empty(n + 1, dtype=np.int64)
     cumflat_ext[0] = 0
     cumflat_ext[1:] = np.cumsum(list_lengths.astype(np.int64))
 
-    boundaries = []
+    boundaries = [0]
     start = 0
     while start < n:
         row_end = min(start + chunk_size, n)

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -903,7 +903,8 @@ def test_list_offsets_multiple_chunks():
     chunked_arrray = pa.chunked_array([struct_array, struct_array[:1], struct_array])
     ext_array = NestedExtensionArray(chunked_arrray)
 
-    desired = chunked_arrray.combine_chunks().field("a").offsets
+    # multi-chunk path returns int64 to avoid overflow when total flat rows exceed 2^31
+    desired = chunked_arrray.combine_chunks().field("a").offsets.cast(pa.int64())
     # pyarrow returns a single bool for ==
     assert ext_array.list_offsets == desired
 

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -12,7 +12,12 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from nested_pandas import NestedDtype
 from nested_pandas.datasets import generate_data
 from nested_pandas.nestedframe.core import NestedFrame
-from nested_pandas.series.ext_array import NestedExtensionArray, convert_df_to_pa_scalar, replace_with_mask
+from nested_pandas.series.ext_array import (
+    NestedExtensionArray,
+    convert_df_to_pa_scalar,
+    replace_with_mask,
+)
+from nested_pandas.series.utils import _MAX_FLAT_SIZE, compute_chunk_boundaries
 
 
 def test_replace_with_mask():
@@ -2150,3 +2155,151 @@ def test__from_factorized():
         NestedExtensionArray._from_factorized(
             [0], NestedExtensionArray.from_sequence([{"a": [1, 2, 3], "b": [4, 5, 6]}])
         )
+
+
+# ── compute_chunk_boundaries ──────────────────────────────────────────────────
+
+
+def test_compute_chunk_boundaries_empty():
+    """Empty input returns empty boundaries."""
+    assert compute_chunk_boundaries(np.array([], dtype=np.int64), chunk_size=10) == []
+
+
+def test_compute_chunk_boundaries_uniform():
+    """Uniform list_lengths produce evenly-spaced boundaries."""
+    # 10 rows, each with 3 inner elements, chunk_size=4
+    boundaries = compute_chunk_boundaries(np.full(10, 3, dtype=np.int64), chunk_size=4)
+    assert boundaries == [4, 8, 10]
+
+
+def test_compute_chunk_boundaries_custom_chunk_size():
+    """chunk_size=1 produces one boundary per row."""
+    n = 5
+    lengths = np.ones(n, dtype=np.int64)
+    boundaries = compute_chunk_boundaries(lengths, chunk_size=1)
+    assert boundaries == list(range(1, n + 1))
+
+
+def test_compute_chunk_boundaries_overflow_guard():
+    """Rows whose flat count would overflow int32 are split at single-row granularity."""
+    # Two rows, each larger than _MAX_FLAT_SIZE would allow in a combined chunk
+    big = _MAX_FLAT_SIZE + 1
+    lengths = np.array([big, big], dtype=np.int64)
+    boundaries = compute_chunk_boundaries(lengths, chunk_size=100)
+    # Each row must be its own chunk because together they exceed _MAX_FLAT_SIZE
+    assert boundaries == [1, 2]
+
+
+def test_compute_chunk_boundaries_single_huge_row():
+    """A single row larger than _MAX_FLAT_SIZE is still returned (unavoidable)."""
+    lengths = np.array([_MAX_FLAT_SIZE + 100], dtype=np.int64)
+    boundaries = compute_chunk_boundaries(lengths, chunk_size=10)
+    assert boundaries == [1]
+
+
+# ── NestedExtensionArray.rechunk ──────────────────────────────────────────────
+
+
+def _make_many_chunk_array(n_rows: int = 20) -> NestedExtensionArray:
+    """Build a NestedExtensionArray with one chunk per row (simulating repeated pd.concat)."""
+    parts = [
+        NestedExtensionArray.from_sequence(
+            [{"a": [float(i), float(i + 1)], "b": [float(i * 10), float(i * 10 + 1)]}]
+        )
+        for i in range(n_rows)
+    ]
+    return NestedExtensionArray._concat_same_type(parts)
+
+
+def test_rechunk_default_chunk_size():
+    """rechunk() with default chunk_size collapses many small chunks into one (for small arrays)."""
+    arr = _make_many_chunk_array(10)
+    assert arr.num_chunks > 1
+    rechunked = arr.rechunk()
+    # For 10 rows, all fit in one DEFAULT_CHUNK_SIZE chunk
+    assert rechunked.num_chunks == 1
+
+
+def test_rechunk_custom_chunk_size():
+    """rechunk(chunk_size=3) produces ceil(n/3) chunks."""
+    n = 9
+    arr = _make_many_chunk_array(n)
+    rechunked = arr.rechunk(chunk_size=3)
+    assert rechunked.num_chunks == 3
+
+
+def test_rechunk_custom_chunk_size_remainder():
+    """rechunk with non-divisible sizes includes a smaller last chunk."""
+    n = 10
+    arr = _make_many_chunk_array(n)
+    rechunked = arr.rechunk(chunk_size=3)
+    assert rechunked.num_chunks == 4  # 3+3+3+1
+
+
+def test_rechunk_single_chunk_input():
+    """rechunk on an already-single-chunk array with chunk_size >= len returns one chunk."""
+    arr = NestedExtensionArray.from_sequence([{"a": [1, 2], "b": [3.0, 4.0]} for _ in range(5)])
+    assert arr.num_chunks == 1
+    rechunked = arr.rechunk(chunk_size=10)
+    assert rechunked.num_chunks == 1
+
+
+def test_rechunk_preserves_data():
+    """rechunk does not alter the values."""
+    arr = _make_many_chunk_array(20)
+    rechunked = arr.rechunk(chunk_size=5)
+    assert arr.equals(rechunked)
+
+
+def test_rechunk_empty_array():
+    """rechunk on an empty array returns an empty array without error."""
+    arr = NestedExtensionArray.from_sequence([], dtype=NestedDtype.from_columns({"a": pa.int64()}))
+    rechunked = arr.rechunk()
+    assert len(rechunked) == 0
+
+
+def test_rechunk_invalid_chunk_size():
+    """rechunk raises ValueError for chunk_size < 1."""
+    arr = _make_many_chunk_array(4)
+    with pytest.raises(ValueError, match="chunk_size must be >= 1"):
+        arr.rechunk(chunk_size=0)
+
+
+def test_rechunk_many_chunks_reduces_count():
+    """Start with 100 chunks, rechunk to ≤10 chunks."""
+    arr = _make_many_chunk_array(100)
+    assert arr.num_chunks == 100
+    rechunked = arr.rechunk(chunk_size=15)
+    assert rechunked.num_chunks <= 7  # ceil(100/15)
+    assert arr.equals(rechunked)
+
+
+# ── set_flat_field with chunked data ──────────────────────────────────────────
+
+
+def test_set_flat_field_on_many_chunk_array():
+    """set_flat_field works correctly when the array has many small chunks."""
+    arr = _make_many_chunk_array(10)
+    assert arr.num_chunks > 1
+
+    # Replace field "b" with a new flat array
+    new_b = np.arange(arr.flat_length, dtype=np.float64)
+    arr.set_flat_field("b", new_b)
+
+    flat_b = arr.pa_table.column("b").combine_chunks().values.to_pylist()
+    assert flat_b == list(new_b)
+
+
+def test_set_flat_field_on_single_chunk_array():
+    """set_flat_field produces the same flat values regardless of chunk structure."""
+    arr_single = NestedExtensionArray.from_sequence([{"a": [1.0, 2.0], "b": [10.0, 11.0]} for _ in range(5)])
+    arr_many = _make_many_chunk_array(5)
+
+    new_b = np.arange(arr_single.flat_length, dtype=np.float64)
+    arr_single.set_flat_field("b", new_b)
+    arr_many.set_flat_field("b", new_b)
+
+    # Both arrays should have the same flat "b" values after the update
+    single_b = arr_single.pa_table.column("b").combine_chunks().values.to_pylist()
+    many_b = arr_many.pa_table.column("b").combine_chunks().values.to_pylist()
+    assert single_b == many_b

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -1224,6 +1224,25 @@ def test__concat_same_type():
     assert actual.equals(desired)
 
 
+def test__concat_same_type_rechunks_fragmented():
+    """Concatenating many one-row arrays produces a non-fragmented result."""
+    n = DEFAULT_MIN_CHUNK_SIZE * 4
+    parts = [NestedExtensionArray.from_sequence([{"a": [float(i)], "b": [float(i)]}]) for i in range(n)]
+    result = NestedExtensionArray._concat_same_type(parts)
+    assert not result.is_fragmented()
+
+
+def test__concat_same_type_skips_rechunk_when_clean():
+    """Concatenating two already-clean large arrays does not trigger rechunking."""
+    chunk = NestedExtensionArray.from_sequence(
+        [{"a": [float(i)], "b": [float(i)]} for i in range(DEFAULT_MIN_CHUNK_SIZE)]
+    )
+    result = NestedExtensionArray._concat_same_type([chunk, chunk])
+    # Two equal-sized chunks: not fragmented, so no rechunk was needed
+    assert result.num_chunks == 2
+    assert not result.is_fragmented()
+
+
 def test_equals():
     """Test that two NestedExtensionArrays are equal."""
     dtype = NestedDtype.from_columns({"a": pa.int64(), "b": pa.float64()})
@@ -2201,6 +2220,12 @@ def test_compute_chunk_boundaries_single_huge_row():
 # ── NestedExtensionArray.rechunk ──────────────────────────────────────────────
 
 
+def _concat_raw(*arrays: NestedExtensionArray) -> NestedExtensionArray:
+    """Concatenate arrays without auto-rechunking, for testing fragmented layouts."""
+    chunks = [chunk for arr in arrays for chunk in arr.list_array.chunks]
+    return NestedExtensionArray(pa.chunked_array(chunks))
+
+
 def _make_many_chunk_array(n_rows: int = 20) -> NestedExtensionArray:
     """Build a NestedExtensionArray with one chunk per row (simulating repeated pd.concat)."""
     parts = [
@@ -2209,7 +2234,7 @@ def _make_many_chunk_array(n_rows: int = 20) -> NestedExtensionArray:
         )
         for i in range(n_rows)
     ]
-    return NestedExtensionArray._concat_same_type(parts)
+    return _concat_raw(*parts)
 
 
 def test_rechunk_default_chunk_size():
@@ -2315,7 +2340,7 @@ def test_is_fragmented_tail_grows_to_full_chunk():
     # Tail of DEFAULT_MIN_CHUNK_SIZE one-row chunks: total == min_chunk_size → fragmented
     one_row = NestedExtensionArray.from_sequence([{"a": [1], "b": [2.0]}])
     parts = [base] + [one_row] * DEFAULT_MIN_CHUNK_SIZE
-    arr = NestedExtensionArray._concat_same_type(parts)
+    arr = _concat_raw(*parts)
     assert arr.is_fragmented()
 
 
@@ -2326,7 +2351,7 @@ def test_is_fragmented_body_chunk_too_small():
     )
     small = NestedExtensionArray.from_sequence([{"a": [1], "b": [2.0]}])
     # Layout: [large, small, large] — the middle chunk is a body chunk and too small
-    arr = NestedExtensionArray._concat_same_type([large, small, large])
+    arr = _concat_raw(large, small, large)
     assert arr.is_fragmented()
 
 

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -13,6 +13,7 @@ from nested_pandas import NestedDtype
 from nested_pandas.datasets import generate_data
 from nested_pandas.nestedframe.core import NestedFrame
 from nested_pandas.series.ext_array import (
+    DEFAULT_MIN_CHUNK_SIZE,
     NestedExtensionArray,
     convert_df_to_pa_scalar,
     replace_with_mask,
@@ -2161,15 +2162,15 @@ def test__from_factorized():
 
 
 def test_compute_chunk_boundaries_empty():
-    """Empty input returns empty boundaries."""
-    assert compute_chunk_boundaries(np.array([], dtype=np.int64), chunk_size=10) == []
+    """Empty input returns [0] (no chunks)."""
+    assert compute_chunk_boundaries(np.array([], dtype=np.int64), chunk_size=10) == [0]
 
 
 def test_compute_chunk_boundaries_uniform():
     """Uniform list_lengths produce evenly-spaced boundaries."""
     # 10 rows, each with 3 inner elements, chunk_size=4
     boundaries = compute_chunk_boundaries(np.full(10, 3, dtype=np.int64), chunk_size=4)
-    assert boundaries == [4, 8, 10]
+    assert boundaries == [0, 4, 8, 10]
 
 
 def test_compute_chunk_boundaries_custom_chunk_size():
@@ -2177,7 +2178,7 @@ def test_compute_chunk_boundaries_custom_chunk_size():
     n = 5
     lengths = np.ones(n, dtype=np.int64)
     boundaries = compute_chunk_boundaries(lengths, chunk_size=1)
-    assert boundaries == list(range(1, n + 1))
+    assert boundaries == list(range(0, n + 1))
 
 
 def test_compute_chunk_boundaries_overflow_guard():
@@ -2187,14 +2188,14 @@ def test_compute_chunk_boundaries_overflow_guard():
     lengths = np.array([big, big], dtype=np.int64)
     boundaries = compute_chunk_boundaries(lengths, chunk_size=100)
     # Each row must be its own chunk because together they exceed _MAX_FLAT_SIZE
-    assert boundaries == [1, 2]
+    assert boundaries == [0, 1, 2]
 
 
 def test_compute_chunk_boundaries_single_huge_row():
     """A single row larger than _MAX_FLAT_SIZE is still returned (unavoidable)."""
     lengths = np.array([_MAX_FLAT_SIZE + 100], dtype=np.int64)
     boundaries = compute_chunk_boundaries(lengths, chunk_size=10)
-    assert boundaries == [1]
+    assert boundaries == [0, 1]
 
 
 # ── NestedExtensionArray.rechunk ──────────────────────────────────────────────
@@ -2272,6 +2273,97 @@ def test_rechunk_many_chunks_reduces_count():
     rechunked = arr.rechunk(chunk_size=15)
     assert rechunked.num_chunks <= 7  # ceil(100/15)
     assert arr.equals(rechunked)
+
+
+# ── is_fragmented ─────────────────────────────────────────────────────────────
+
+
+def test_is_fragmented_single_clean_chunk():
+    """A freshly constructed single-chunk array is not fragmented."""
+    arr = NestedExtensionArray.from_sequence(
+        [{"a": [1, 2], "b": [3.0, 4.0]} for _ in range(DEFAULT_MIN_CHUNK_SIZE)]
+    )
+    assert arr.num_chunks == 1
+    assert not arr.is_fragmented()
+
+
+def test_is_fragmented_many_tiny_chunks():
+    """Many 1-row chunks whose tail total >= min_chunk_size are fragmented."""
+    arr = _make_many_chunk_array(DEFAULT_MIN_CHUNK_SIZE * 2)
+    assert arr.num_chunks == DEFAULT_MIN_CHUNK_SIZE * 2
+    assert arr.is_fragmented()
+
+
+def test_is_fragmented_small_tail_not_fragmented():
+    """A large base chunk plus a small tail (total < min_chunk_size) is not fragmented."""
+    base = NestedExtensionArray.from_sequence(
+        [{"a": [1, 2], "b": [3.0, 4.0]} for _ in range(DEFAULT_MIN_CHUNK_SIZE)]
+    )
+    small = NestedExtensionArray.from_sequence(
+        [{"a": [1], "b": [2.0]} for _ in range(DEFAULT_MIN_CHUNK_SIZE // 2 - 1)]
+    )
+    arr = NestedExtensionArray._concat_same_type([base, small])
+    assert arr.num_chunks == 2
+    assert not arr.is_fragmented()
+
+
+def test_is_fragmented_tail_grows_to_full_chunk():
+    """Once the tail accumulates >= min_chunk_size rows the array is fragmented."""
+    base = NestedExtensionArray.from_sequence(
+        [{"a": [1, 2], "b": [3.0, 4.0]} for _ in range(DEFAULT_MIN_CHUNK_SIZE)]
+    )
+    # Tail of DEFAULT_MIN_CHUNK_SIZE one-row chunks: total == min_chunk_size → fragmented
+    one_row = NestedExtensionArray.from_sequence([{"a": [1], "b": [2.0]}])
+    parts = [base] + [one_row] * DEFAULT_MIN_CHUNK_SIZE
+    arr = NestedExtensionArray._concat_same_type(parts)
+    assert arr.is_fragmented()
+
+
+def test_is_fragmented_body_chunk_too_small():
+    """A small chunk surrounded by large ones (not in the tail) is fragmented."""
+    large = NestedExtensionArray.from_sequence(
+        [{"a": [1], "b": [2.0]} for _ in range(DEFAULT_MIN_CHUNK_SIZE)]
+    )
+    small = NestedExtensionArray.from_sequence([{"a": [1], "b": [2.0]}])
+    # Layout: [large, small, large] — the middle chunk is a body chunk and too small
+    arr = NestedExtensionArray._concat_same_type([large, small, large])
+    assert arr.is_fragmented()
+
+
+def test_is_fragmented_after_rechunk():
+    """After rechunk(), is_fragmented() returns False."""
+    arr = _make_many_chunk_array(DEFAULT_MIN_CHUNK_SIZE * 2)
+    assert arr.is_fragmented()
+    assert not arr.rechunk().is_fragmented()
+
+
+def test_is_fragmented_custom_min_chunk_size():
+    """min_chunk_size parameter controls the size threshold."""
+    # 2 chunks of n=500 rows each
+    n = 500
+    arr = _make_many_chunk_array(n * 2)
+    rechunked = arr.rechunk(chunk_size=n)
+    assert rechunked.num_chunks == 2
+    # With min_chunk_size=1000: both chunks are body chunks and 500 < 1000 → fragmented
+    assert rechunked.is_fragmented(min_chunk_size=1000)
+    # With min_chunk_size=100: both chunks are large enough → not fragmented
+    assert not rechunked.is_fragmented(min_chunk_size=100)
+
+
+def test_rechunk_fast_path_returns_self():
+    """rechunk() returns self (not a copy) when the array is already clean."""
+    arr = NestedExtensionArray.from_sequence(
+        [{"a": [1, 2], "b": [3.0, 4.0]} for _ in range(DEFAULT_MIN_CHUNK_SIZE)]
+    )
+    assert not arr.is_fragmented()
+    assert arr.rechunk() is arr
+
+
+def test_rechunk_copies_when_fragmented():
+    """rechunk() returns a different object when the array is fragmented."""
+    arr = _make_many_chunk_array(DEFAULT_MIN_CHUNK_SIZE * 2)
+    assert arr.is_fragmented()
+    assert arr.rechunk() is not arr
 
 
 # ── set_flat_field with chunked data ──────────────────────────────────────────

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -1198,6 +1198,18 @@ def test_pickability():
     assert ext_array.equals(pickled)
 
 
+def test_pickability_multi_chunk():
+    """Test that the extension array preserves chunks across pickle round-trip."""
+    chunk1 = NestedExtensionArray.from_sequence([{"a": [1, 2], "b": [-1.0, -2.0]}, {"a": [3], "b": [-3.0]}])
+    chunk2 = NestedExtensionArray.from_sequence([{"a": [4, 5, 6], "b": [-4.0, -5.0, -6.0]}, None])
+    ext_array = NestedExtensionArray._concat_same_type([chunk1, chunk2])
+    assert ext_array.num_chunks == 2
+
+    pickled = pickle.loads(pickle.dumps(ext_array))
+    assert ext_array.equals(pickled)
+    assert pickled.num_chunks == 2
+
+
 def test__concat_same_type():
     """Test concatenating of three NestedExtensionArrays with the same dtype."""
     dtype = NestedDtype.from_columns({"a": pa.int64(), "b": pa.float64()})

--- a/tests/nested_pandas/series/test_packer.py
+++ b/tests/nested_pandas/series/test_packer.py
@@ -558,7 +558,7 @@ def test_view_sorted_series_as_list_array_chunked_input():
         name="a",
     )
 
-    actual = packer.view_sorted_series_as_list_array(series, offset, unique_index)
+    actual = packer.view_sorted_series_as_list_array(series, offset=offset, unique_index=unique_index)
     assert_series_equal(actual, desired)
 
 
@@ -589,7 +589,7 @@ def test_view_sorted_series_as_list_array_chunked_input():
 def test_calculate_sorted_index_offsets(index, offsets):
     """Test calculate_sorted_index_offsets()."""
     actual = packer.calculate_sorted_index_offsets(index)
-    assert actual.dtype == np.int32
+    assert actual.dtype == np.int64
     assert_array_equal(actual, offsets)
 
 


### PR DESCRIPTION
This is an alternative approach to support large nested arrays, >2**31 nested values; see #462 for another approach. It is aimed at two things: 1) prevent `offsets` overflow, and 2) prevent small chunks appearance and memory borrowing with re-chunking. In contrast to #462, this is not a breaking change, but it applies a lot of trade-offs and tuning hyperparameters, which are not validated for the best performance.

Closes #95