### PR TITLE
Fix count_nested returning float NaN instead of int zeros (#472)

### DIFF
--- a/src/nested_pandas/utils/utils.py
+++ b/src/nested_pandas/utils/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pyarrow as pa
 import pandas as pd
 
 from nested_pandas import NestedFrame
@@ -59,6 +60,7 @@ def count_nested(df, nested, by=None, join=True) -> NestedFrame:
 
     if by is None:
         counts = pd.Series(df[nested].nest.list_lengths, name=f"n_{nested}", index=df.index)
+        counts = counts.astype(pd.ArrowDtype(pa.int32()))
     else:
         counts = df.map_rows(
             lambda x: dict(zip(*np.unique(x, return_counts=True), strict=False)),
@@ -67,6 +69,7 @@ def count_nested(df, nested, by=None, join=True) -> NestedFrame:
         )
         counts = counts.rename(columns={colname: f"n_{nested}_{colname}" for colname in counts.columns})
         counts = counts.reindex(sorted(counts.columns), axis=1)
+        counts = counts.fillna(0).astype(pd.ArrowDtype(pa.int32()))
     if join:
         return df.join(counts)
     # else just return the counts NestedFrame

--- a/src/nested_pandas/utils/utils.py
+++ b/src/nested_pandas/utils/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
-import pyarrow as pa
 import pandas as pd
+import pyarrow as pa
 
 from nested_pandas import NestedFrame
 

--- a/src/nested_pandas/utils/utils.py
+++ b/src/nested_pandas/utils/utils.py
@@ -67,9 +67,10 @@ def count_nested(df, nested, by=None, join=True) -> NestedFrame:
             columns=f"{nested}.{by}",
             row_container="args",
         )
+        counts = counts.astype(pd.ArrowDtype(pa.int32()))
         counts = counts.rename(columns={colname: f"n_{nested}_{colname}" for colname in counts.columns})
         counts = counts.reindex(sorted(counts.columns), axis=1)
-        counts = counts.fillna(0).astype(pd.ArrowDtype(pa.int32()))
+        counts = counts.fillna(0)
     if join:
         return df.join(counts)
     # else just return the counts NestedFrame

--- a/tests/nested_pandas/utils/test_utils.py
+++ b/tests/nested_pandas/utils/test_utils.py
@@ -118,11 +118,8 @@ def test_count_nested_arrow_int32_dtype():
     filtered = base.query("nested.flux > 1.5")
     counts = count_nested(filtered, "nested", by="band", join=False)
 
-    expected_dtype = pd.ArrowDtype(pa.int32())
     for col in counts.columns:
-        assert counts[col].dtype == expected_dtype, (
-            f"Column {col} has dtype {counts[col].dtype}, expected {expected_dtype}"
-        )
+        assert counts[col].dtype == pd.ArrowDtype(pa.int32())
 
     # Values should be 0, not NaN, for missing band/row combinations
     assert 0 in counts.values or all(counts.notna().all())
@@ -140,5 +137,4 @@ def test_count_nested_no_by_arrow_int32_dtype():
     base = base.join_nested(nested, "nested")
 
     counts = count_nested(base, "nested", join=False)
-    expected_dtype = pd.ArrowDtype(pa.int32())
-    assert counts["n_nested"].dtype == expected_dtype
+    assert counts["n_nested"].dtype == pd.ArrowDtype(pa.int32())

--- a/tests/nested_pandas/utils/test_utils.py
+++ b/tests/nested_pandas/utils/test_utils.py
@@ -94,3 +94,49 @@ def test_check_expr_nesting():
     b4 = base.join_nested(nested, "test")
     assert b4.extract_nest_names("test.c>5&b==2") == {"test", ""}
     assert b4.extract_nest_names("test.c > 5 & b == 2") == {"test", ""}
+
+
+def test_count_nested_arrow_int32_dtype():
+    """Test that count_nested always returns arrow int32 columns, even after
+    a query that causes some by-values to be absent for certain rows.
+    Regression test for https://github.com/lincc-frameworks/nested-pandas/issues/472
+    """
+    import pyarrow as pa
+
+    base = NestedFrame(data={"a": [1, 2, 3]}, index=[0, 1, 2])
+    nested = pd.DataFrame(
+        data={
+            "flux": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "band": ["g", "r", "g", "r", "g"],
+        },
+        index=[0, 0, 1, 1, 2],
+    )
+    base = base.join_nested(nested, "nested")
+
+    # Query so that row 0 only has band "g", row 1 only has band "r" — missing values
+    # would previously produce NaN float columns instead of 0 int columns.
+    filtered = base.query("nested.flux > 1.5")
+    counts = count_nested(filtered, "nested", by="band", join=False)
+
+    expected_dtype = pd.ArrowDtype(pa.int32())
+    for col in counts.columns:
+        assert counts[col].dtype == expected_dtype, f"Column {col} has dtype {counts[col].dtype}, expected {expected_dtype}"
+
+    # Values should be 0, not NaN, for missing band/row combinations
+    assert 0 in counts.values or all(counts.notna().all())
+
+
+def test_count_nested_no_by_arrow_int32_dtype():
+    """Test that count_nested without 'by' returns arrow int32 column."""
+    import pyarrow as pa
+
+    base = NestedFrame(data={"a": [1, 2, 3]}, index=[0, 1, 2])
+    nested = pd.DataFrame(
+        data={"flux": [1.0, 2.0, 3.0, 4.0]},
+        index=[0, 0, 1, 2],
+    )
+    base = base.join_nested(nested, "nested")
+
+    counts = count_nested(base, "nested", join=False)
+    expected_dtype = pd.ArrowDtype(pa.int32())
+    assert counts["n_nested"].dtype == expected_dtype

--- a/tests/nested_pandas/utils/test_utils.py
+++ b/tests/nested_pandas/utils/test_utils.py
@@ -120,7 +120,9 @@ def test_count_nested_arrow_int32_dtype():
 
     expected_dtype = pd.ArrowDtype(pa.int32())
     for col in counts.columns:
-        assert counts[col].dtype == expected_dtype, f"Column {col} has dtype {counts[col].dtype}, expected {expected_dtype}"
+        assert counts[col].dtype == expected_dtype, (
+            f"Column {col} has dtype {counts[col].dtype}, expected {expected_dtype}"
+        )
 
     # Values should be 0, not NaN, for missing band/row combinations
     assert 0 in counts.values or all(counts.notna().all())


### PR DESCRIPTION
Use arrow-int32 dtype for result columns so missing by-values yield 0 instead of NaN, keeping the dtype as integer after queries.
Fixes #472