### PR TITLE
Fix #460: read_parquet(use_pandas_metadata: bool = True)

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -85,8 +85,8 @@ def read_parquet(
     ignore_pandas_metadata: bool, default=True
         If True (default), ignore the pandas metadata stored in the Parquet file's
         schema when constructing the NestedFrame. This prevents the index from being
-        set based on the pandas metadata, and avoids other inconsistencies introduced
-        by stale or unexpected metadata embedded in older Parquet files.
+        set based on the pandas metadata, and avoids column dtype casting driven by
+        stale pandas metadata embedded in older Parquet files.
 
         .. note::
             This differs from the default pandas behavior (pd.read_parquet),
@@ -464,8 +464,8 @@ def from_pyarrow(
     ignore_pandas_metadata: bool, default=True
         If True (default), ignore the pandas metadata stored in the Parquet file's
         schema when constructing the NestedFrame. This prevents the index from being
-        set based on the pandas metadata, and avoids other inconsistencies introduced
-        by stale or unexpected metadata embedded in older Parquet files.
+        set based on the pandas metadata, and avoids column dtype casting driven by
+        stale pandas metadata embedded in older Parquet files.
 
         .. note::
             This differs from the default pandas behavior (pd.read_parquet),

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -85,8 +85,8 @@ def read_parquet(
     ignore_pandas_metadata: bool, default=True
         If True (default), ignore the pandas metadata stored in the Parquet file's
         schema when constructing the NestedFrame. This prevents the index from being
-        set based on the pandas metadata, and avoids column dtype casting driven by
-        stale pandas metadata embedded in older Parquet files.
+        set based on the pandas metadata, and avoids unintended column dtype
+        casting from embedded pandas metadata.
 
         .. note::
             This differs from the default pandas behavior (pd.read_parquet),
@@ -464,8 +464,8 @@ def from_pyarrow(
     ignore_pandas_metadata: bool, default=True
         If True (default), ignore the pandas metadata stored in the Parquet file's
         schema when constructing the NestedFrame. This prevents the index from being
-        set based on the pandas metadata, and avoids column dtype casting driven by
-        stale pandas metadata embedded in older Parquet files.
+        set based on the pandas metadata, and avoids unintended column dtype
+        casting from embedded pandas metadata.
 
         .. note::
             This differs from the default pandas behavior (pd.read_parquet),

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -86,8 +86,7 @@ def read_parquet(
         If True (default), apply the pandas metadata stored in the Parquet
         file's schema when constructing the NestedFrame (e.g. restoring the
         index and column dtypes). This matches the default behavior of
-        pd.read_parquet. Set to False to ignore the metadata, which can
-        be useful when the embedded metadata is stale or inconsistent.
+        pd.read_parquet. Set to False to ignore the metadata.
     kwargs: dict
         Keyword arguments passed to `pyarrow.parquet.read_table`
 
@@ -460,8 +459,7 @@ def from_pyarrow(
         If True (default), apply the pandas metadata stored in the Parquet
         file's schema when constructing the NestedFrame (e.g. restoring the
         index and column dtypes). This matches the default behavior of
-        pd.read_parquet. Set to False to ignore the metadata, which can
-        be useful when the embedded metadata is stale or inconsistent.
+        pd.read_parquet. Set to False to ignore the metadata.
 
     Returns
     -------

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -36,6 +36,7 @@ def read_parquet(
     reject_nesting: list[str] | str | None = None,
     autocast_list: bool = False,
     is_dir: bool | None = None,
+    ignore_pandas_metadata: bool = True,
     **kwargs,
 ) -> NestedFrame:
     """Load a parquet object from a file path into a NestedFrame.
@@ -81,6 +82,17 @@ def read_parquet(
         `upath.is_dir()` to identify the type of pointer. This argument is ignored
         for HTTP, as inferring the type for HTTP is particularly expensive because
         it requires downloading the contents of the pointer in its entirety.
+    ignore_pandas_metadata: bool, default=True
+        If True (default), ignore the pandas metadata stored in the Parquet file's
+        schema when constructing the NestedFrame. This prevents the index from being
+        set based on the pandas metadata, and avoids other inconsistencies introduced
+        by stale or unexpected metadata embedded in older Parquet files.
+
+        .. note::
+            This differs from the default pandas behavior (pd.read_parquet),
+            which reads and applies pandas metadata by default. nested-pandas
+            intentionally defaults to True to provide consistent behavior
+            regardless of how the Parquet file was created.
     kwargs: dict
         Keyword arguments passed to `pyarrow.parquet.read_table`
 
@@ -195,7 +207,12 @@ def read_parquet(
         for col, struct in structs.items():
             table = table.append_column(col, struct)
 
-    return from_pyarrow(table, reject_nesting=reject_nesting, autocast_list=autocast_list)
+    return from_pyarrow(
+        table,
+        reject_nesting=reject_nesting,
+        autocast_list=autocast_list,
+        ignore_pandas_metadata=ignore_pandas_metadata,
+    )
 
 
 def _read_parquet_into_table(
@@ -427,6 +444,7 @@ def from_pyarrow(
     table: pa.Table,
     reject_nesting: list[str] | str | None = None,
     autocast_list: bool = False,
+    ignore_pandas_metadata: bool = True,
 ) -> NestedFrame:
     """
     Load a pyarrow Table object into a NestedFrame.
@@ -443,6 +461,17 @@ def from_pyarrow(
         Columns specified here will be read using the corresponding pandas.ArrowDtype.
     autocast_list: bool, default=False
         If True, automatically cast list columns to nested columns with NestedDType.
+    ignore_pandas_metadata: bool, default=True
+        If True (default), ignore the pandas metadata stored in the Parquet file's
+        schema when constructing the NestedFrame. This prevents the index from being
+        set based on the pandas metadata, and avoids other inconsistencies introduced
+        by stale or unexpected metadata embedded in older Parquet files.
+
+        .. note::
+            This differs from the default pandas behavior (pd.read_parquet),
+            which reads and applies pandas metadata by default. nested-pandas
+            intentionally defaults to True to provide consistent behavior
+            regardless of how the Parquet file was created.
 
     Returns
     -------
@@ -458,7 +487,14 @@ def from_pyarrow(
     # Convert to NestedFrame
     # not zero-copy, but reduce memory pressure via the self_destruct kwarg
     # https://arrow.apache.org/docs/python/pandas.html#reducing-memory-use-in-table-to-pandas
-    df = NestedFrame(table.to_pandas(types_mapper=pd.ArrowDtype, split_blocks=True, self_destruct=True))
+    df = NestedFrame(
+        table.to_pandas(
+            types_mapper=pd.ArrowDtype,
+            split_blocks=True,
+            self_destruct=True,
+            ignore_metadata=ignore_pandas_metadata,
+        )
+    )
     # Attempt to cast struct columns to NestedDTypes
     df = _cast_struct_cols_to_nested(df, reject_nesting)
 

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -83,16 +83,11 @@ def read_parquet(
         for HTTP, as inferring the type for HTTP is particularly expensive because
         it requires downloading the contents of the pointer in its entirety.
     use_pandas_metadata: bool, default=True
-        If True (default), use the pandas metadata stored in the Parquet file's
-        schema when constructing the NestedFrame. This prevents the index from being
-        set based on the pandas metadata, and avoids unintended column dtype
-        casting from embedded pandas metadata.
-
-        .. note::
-            This differs from the default pandas behavior (pd.read_parquet),
-            which reads and applies pandas metadata by default. nested-pandas
-            intentionally defaults to True to provide consistent behavior
-            regardless of how the Parquet file was created.
+        If True (default), apply the pandas metadata stored in the Parquet
+        file's schema when constructing the NestedFrame (e.g. restoring the
+        index and column dtypes). This matches the default behavior of
+        pd.read_parquet. Set to False to ignore the metadata, which can
+        be useful when the embedded metadata is stale or inconsistent.
     kwargs: dict
         Keyword arguments passed to `pyarrow.parquet.read_table`
 
@@ -462,16 +457,11 @@ def from_pyarrow(
     autocast_list: bool, default=False
         If True, automatically cast list columns to nested columns with NestedDType.
     use_pandas_metadata: bool, default=True
-        If True (default), use the pandas metadata stored in the Parquet file's
-        schema when constructing the NestedFrame. This prevents the index from being
-        set based on the pandas metadata, and avoids unintended column dtype
-        casting from embedded pandas metadata.
-
-        .. note::
-            This differs from the default pandas behavior (pd.read_parquet),
-            which reads and applies pandas metadata by default. nested-pandas
-            intentionally defaults to True to provide consistent behavior
-            regardless of how the Parquet file was created.
+        If True (default), apply the pandas metadata stored in the Parquet
+        file's schema when constructing the NestedFrame (e.g. restoring the
+        index and column dtypes). This matches the default behavior of
+        pd.read_parquet. Set to False to ignore the metadata, which can
+        be useful when the embedded metadata is stale or inconsistent.
 
     Returns
     -------

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -36,7 +36,7 @@ def read_parquet(
     reject_nesting: list[str] | str | None = None,
     autocast_list: bool = False,
     is_dir: bool | None = None,
-    ignore_pandas_metadata: bool = True,
+    use_pandas_metadata: bool = True,
     **kwargs,
 ) -> NestedFrame:
     """Load a parquet object from a file path into a NestedFrame.
@@ -82,8 +82,8 @@ def read_parquet(
         `upath.is_dir()` to identify the type of pointer. This argument is ignored
         for HTTP, as inferring the type for HTTP is particularly expensive because
         it requires downloading the contents of the pointer in its entirety.
-    ignore_pandas_metadata: bool, default=True
-        If True (default), ignore the pandas metadata stored in the Parquet file's
+    use_pandas_metadata: bool, default=True
+        If True (default), use the pandas metadata stored in the Parquet file's
         schema when constructing the NestedFrame. This prevents the index from being
         set based on the pandas metadata, and avoids unintended column dtype
         casting from embedded pandas metadata.
@@ -211,7 +211,7 @@ def read_parquet(
         table,
         reject_nesting=reject_nesting,
         autocast_list=autocast_list,
-        ignore_pandas_metadata=ignore_pandas_metadata,
+        use_pandas_metadata=use_pandas_metadata,
     )
 
 
@@ -444,7 +444,7 @@ def from_pyarrow(
     table: pa.Table,
     reject_nesting: list[str] | str | None = None,
     autocast_list: bool = False,
-    ignore_pandas_metadata: bool = True,
+    use_pandas_metadata: bool = True,
 ) -> NestedFrame:
     """
     Load a pyarrow Table object into a NestedFrame.
@@ -461,8 +461,8 @@ def from_pyarrow(
         Columns specified here will be read using the corresponding pandas.ArrowDtype.
     autocast_list: bool, default=False
         If True, automatically cast list columns to nested columns with NestedDType.
-    ignore_pandas_metadata: bool, default=True
-        If True (default), ignore the pandas metadata stored in the Parquet file's
+    use_pandas_metadata: bool, default=True
+        If True (default), use the pandas metadata stored in the Parquet file's
         schema when constructing the NestedFrame. This prevents the index from being
         set based on the pandas metadata, and avoids unintended column dtype
         casting from embedded pandas metadata.
@@ -492,7 +492,7 @@ def from_pyarrow(
             types_mapper=pd.ArrowDtype,
             split_blocks=True,
             self_destruct=True,
-            ignore_metadata=ignore_pandas_metadata,
+            ignore_metadata=not use_pandas_metadata,
         )
     )
     # Attempt to cast struct columns to NestedDTypes

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -545,3 +545,24 @@ def test_issue_428(size):
         nf = read_parquet(file_path, columns=["nested.t"])
         assert nf.columns == ["nested"]
         assert nf.nested.nest.columns == ["t"]
+
+
+def test_ignore_pandas_metadata_default():
+    """Test that ignore_pandas_metadata=True (default) ignores pandas metadata index.
+    Regression test for https://github.com/lincc-frameworks/nested-pandas/issues/460
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = os.path.join(tmpdir, "tmp.parquet")
+
+        # Write a parquet file with a custom index stored in pandas metadata
+        df = pd.DataFrame({"a": [1, 2, 3], "custom_idx": [10, 20, 30]})
+        df = df.set_index("custom_idx")
+        df.to_parquet(file_path)
+
+        # Default (ignore_pandas_metadata=True): index should NOT be restored from metadata
+        nf = read_parquet(file_path)
+        assert nf.index.name != "custom_idx", "Index should not be set from pandas metadata by default"
+
+        # Explicit False: index IS restored from pandas metadata, matching pd.read_parquet behavior
+        nf_with_meta = read_parquet(file_path, ignore_pandas_metadata=False)
+        assert nf_with_meta.index.name == "custom_idx"

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -547,8 +547,8 @@ def test_issue_428(size):
         assert nf.nested.nest.columns == ["t"]
 
 
-def test_ignore_pandas_metadata_default():
-    """Test that ignore_pandas_metadata=True (default) ignores pandas metadata index.
+def test_use_pandas_metadata():
+    """Test use_pandas_metadata parameter in read_parquet.
     Regression test for https://github.com/lincc-frameworks/nested-pandas/issues/460
     """
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -559,10 +559,10 @@ def test_ignore_pandas_metadata_default():
         df = df.set_index("custom_idx")
         df.to_parquet(file_path)
 
-        # Default (ignore_pandas_metadata=True): index should NOT be restored from metadata
+        # Default (use_pandas_metadata=True): index IS restored from metadata
         nf = read_parquet(file_path)
-        assert nf.index.name != "custom_idx", "Index should not be set from pandas metadata by default"
+        assert nf.index.name == "custom_idx"
 
-        # Explicit False: index IS restored from pandas metadata, matching pd.read_parquet behavior
-        nf_with_meta = read_parquet(file_path, ignore_pandas_metadata=False)
-        assert nf_with_meta.index.name == "custom_idx"
+        # Explicit False: index is NOT restored from pandas metadata
+        nf_no_meta = read_parquet(file_path, use_pandas_metadata=False)
+        assert nf_no_meta.index.name != "custom_idx"


### PR DESCRIPTION
Adds `read_parquet(use_pandas_metadata: bool = True)`, which allows to ignore index and other pandas metadata.

From LSDB/hats side we should pass `use_pandas_metadata=False` to address #460 and https://github.com/astronomy-commons/lsdb/issues/1265

Closes #460 