### PR TITLE
Nicer HTML repr for small nested elements

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -122,26 +122,31 @@ class NestedFrame(pd.DataFrame):
 
         # Display nested columns as small html dataframes with a single row
         def repack_row(chunk, header=True):
-            # If the chunk is None, just return None
+            # If the chunk is None or empty, return None (displayed same as Null)
             if chunk is None or len(chunk) == 0:
                 return None
-            # Grab length, then truncate to one row for display
             n_rows = len(chunk)
-            chunk = chunk.head(1).round(8)  # only show first row
-            chunk.astype({col: object for col in chunk.columns})  # cast to string for info row
 
-            # Add a row that shows the number of additional rows not shown
-            len_row = pd.DataFrame(
-                {
-                    col: [f"<i>+{n_rows - 1} rows</i>"] if i == 0 else ["..."]
-                    for i, col in enumerate(chunk.columns)
-                }
-            )
-            chunk = pd.concat([chunk, len_row], ignore_index=True)
+            if n_rows <= 2:
+                # For 1 or 2 rows, show all rows without a footer
+                chunk = chunk.round(8)
+                max_rows_html = n_rows
+            else:
+                # For 3+ rows, show first row and a "+N rows" footer
+                chunk = chunk.head(1).round(8)
+                chunk.astype({col: object for col in chunk.columns})  # cast to string for info row
+                len_row = pd.DataFrame(
+                    {
+                        col: [f"<i>+{n_rows - 1} rows</i>"] if i == 0 else ["..."]
+                        for i, col in enumerate(chunk.columns)
+                    }
+                )
+                chunk = pd.concat([chunk, len_row], ignore_index=True)
+                max_rows_html = 2
 
             # Estimate width and resize
             html_res = chunk.to_html(
-                max_rows=2,
+                max_rows=max_rows_html,
                 max_cols=5,
                 show_dimensions=False,
                 index=False,

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -85,6 +85,28 @@ def test_html_repr_empty_list():
     assert "+-1 rows" not in html and "None" in html
 
 
+def test_html_repr_small_rows():
+    """Make sure the html representation handles small nested sub-frames correctly"""
+    # 0 rows: displayed as None (same as Null)
+    base = NestedFrame(data={"a": [1, 2], "b": [2, 4], "c": [[1, 2, 3], []]}, index=[0, 1])
+    base = base.nest_lists(columns=["c"], name="nested")
+    html = base._repr_html_()
+    assert "+0 rows" not in html
+    assert "None" in html  # empty sub-frame shown as None
+
+    # 1 row: no "+0 rows" footer
+    base = NestedFrame(data={"a": [1, 2], "b": [2, 4], "c": [[42], [1, 2, 3]]}, index=[0, 1])
+    base = base.nest_lists(columns=["c"], name="nested")
+    html = base._repr_html_()
+    assert "+0 rows" not in html
+
+    # 2 rows: show both rows, no "+1 rows" footer
+    base = NestedFrame(data={"a": [1], "b": [2], "c": [[10, 20]]}, index=[0])
+    base = base.nest_lists(columns=["c"], name="nested")
+    html = base._repr_html_()
+    assert "+1 rows" not in html
+
+
 def test_all_columns():
     """Test the all_columns function"""
 


### PR DESCRIPTION
Change representation for small nested elements: one or two nested rows

**Before:**
<img width="483" height="503" alt="Screenshot 2026-04-09 at 14 20 35" src="https://github.com/user-attachments/assets/d4f006d3-d0b8-4ad0-acfd-2e9be278610d" />

**After:**
<img width="494" height="472" alt="Screenshot 2026-04-09 at 14 20 57" src="https://github.com/user-attachments/assets/a03f0f76-5651-4d38-85c0-cdffc8b52e6b" />
