### PR TITLE
Add docs for `join_nested` on multiple cols

### DIFF
--- a/docs/tutorials/data_loading_notebook.ipynb
+++ b/docs/tutorials/data_loading_notebook.ipynb
@@ -211,10 +211,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "nested = pd.DataFrame(\n",
     "    data={\n",

--- a/docs/tutorials/data_loading_notebook.ipynb
+++ b/docs/tutorials/data_loading_notebook.ipynb
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then create an additional pandas dataframes for the nested columns and pack them into our `NestedFrame` with `NestedFrame.join_nested()` function. `join_nested` will align the nest based on the index by default (a column may be selected instead via the `on` kwarg), as we see the `nested` `DataFrame` has a repeated index corresponding to the `nf` `NestedFrame`."
+    "We can then create an additional pandas dataframes for the nested columns and pack them into our `NestedFrame` with `NestedFrame.join_nested()` function. `join_nested` will align the nest based on the index by default (one or more columns may be selected instead via the `on` kwarg), as we see the `nested` `DataFrame` has a repeated index corresponding to the `nf` `NestedFrame`."
    ]
   },
   {
@@ -201,6 +201,30 @@
     "\n",
     "nf = nf.join_nested(nested, \"nested2\")\n",
     "nf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the join key spans multiple columns, pass a list to `on`. The matching columns are used only as join keys and are dropped from the nested structure, while the original index is preserved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nested = pd.DataFrame(\n",
+    "    data={\n",
+    "        \"a\": [1, 1, 2, 3],\n",
+    "        \"b\": [2, 2, 4, 5],\n",
+    "        \"c\": [100, 200, 300, 400],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "nf = nf.join_nested(nested, \"nested3\", on=[\"a\", \"b\"])"
    ]
   },
   {

--- a/docs/tutorials/data_loading_notebook.ipynb
+++ b/docs/tutorials/data_loading_notebook.ipynb
@@ -211,10 +211,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "nested = pd.DataFrame(\n",
     "    data={\n",
@@ -224,7 +224,8 @@
     "    }\n",
     ")\n",
     "\n",
-    "nf = nf.join_nested(nested, \"nested3\", on=[\"a\", \"b\"])"
+    "nf = nf.join_nested(nested, \"nested3\", on=[\"a\", \"b\"])\n",
+    "nf"
    ]
   },
   {

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -421,8 +421,10 @@ class NestedFrame(pd.DataFrame):
               index, and sort it lexicographically.
             - inner: form intersection of calling frame's index with other
               frame's index, preserving the order of the calling index.
-        on : str, default: None
-            A column in the list
+        on : str or list of str, default: None
+            Column(s) in the calling frame to join on instead of the index.
+            The original index is always preserved. The column(s) are used
+            only as join keys and are dropped from the nested structure.
         dtype : dtype or None
             NestedDtype to use for the nested column; pd.ArrowDtype or
             pa.DataType can also be used to specify the nested dtype. If None,
@@ -437,6 +439,7 @@ class NestedFrame(pd.DataFrame):
         --------
 
         >>> import nested_pandas as npd
+
         >>> nf = npd.NestedFrame({"a": [1, 2, 3], "b": [4, 5, 6]},
         ...            index=[0,1,2])
         >>> nf2 = npd.NestedFrame({"c":[1,2,3,4,5,6,7,8,9]},
@@ -447,6 +450,17 @@ class NestedFrame(pd.DataFrame):
         0  1  4  [{c: 1}; …] (3 rows)
         1  2  5  [{c: 4}; …] (3 rows)
         2  3  6  [{c: 7}; …] (3 rows)
+
+        >>> # We can also align on columns. The index is preserved.
+        >>> nf = npd.NestedFrame({"a": [1,2,2,3], "b": [4,4,5,6]}).set_index(["a", "b"])
+        >>> nf2 = npd.NestedFrame({"a": [1,2,2,2], "b": [4,4,4,5], "c": [1,2,3,4]})
+        >>> nf.join_nested(nf2, "nested", on=["a", "b"]) # doctest: +NORMALIZE_WHITESPACE
+                            nested
+        a b
+        1 4              [{c: 1}]
+        2 4  [{c: 2}; …] (2 rows)
+          5              [{c: 4}]
+        3 6                  None
         """
         return self.join_nested(obj, name, how=how, on=on, dtype=dtype)
 
@@ -487,8 +501,10 @@ class NestedFrame(pd.DataFrame):
               index, and sort it lexicographically.
             - inner: form intersection of calling frame's index with other
               frame's index, preserving the order of the calling index.
-        on : str, default: None
-            A column in the list
+        on : str or list of str, default: None
+            Column(s) in the calling frame to join on instead of the index.
+            The original index is always preserved. The column(s) are used
+            only as join keys and are dropped from the nested structure.
         dtype : dtype or None
             NestedDtype to use for the nested column; pd.ArrowDtype or
             pa.DataType can also be used to specify the nested dtype. If None,
@@ -503,6 +519,7 @@ class NestedFrame(pd.DataFrame):
         --------
 
         >>> import nested_pandas as npd
+
         >>> nf = npd.NestedFrame({"a": [1, 2, 3], "b": [4, 5, 6]},
         ...            index=[0,1,2])
         >>> nf2 = npd.NestedFrame({"c":[1,2,3,4,5,6,7,8,9]},
@@ -513,9 +530,18 @@ class NestedFrame(pd.DataFrame):
         0  1  4  [{c: 1}; …] (3 rows)
         1  2  5  [{c: 4}; …] (3 rows)
         2  3  6  [{c: 7}; …] (3 rows)
+
+        >>> # We can also align on columns. The index is preserved.
+        >>> nf = npd.NestedFrame({"a": [1,2,2,3], "b": [4,4,5,6]}).set_index(["a", "b"])
+        >>> nf2 = npd.NestedFrame({"a": [1,2,2,2], "b": [4,4,4,5], "c": [1,2,3,4]})
+        >>> nf.join_nested(nf2, "nested", on=["a", "b"]) # doctest: +NORMALIZE_WHITESPACE
+                            nested
+        a b
+        1 4              [{c: 1}]
+        2 4  [{c: 2}; …] (2 rows)
+          5              [{c: 4}]
+        3 6                  None
         """
-        if on is not None and not isinstance(on, str):
-            raise ValueError("Currently we only support a single column for 'on'")
         # Add sources to objects
         packed = pack(obj, name=name, on=on, dtype=dtype)
         new_df = self.copy()

--- a/tests/nested_pandas/nestedframe/test_nestedframe.py
+++ b/tests/nested_pandas/nestedframe/test_nestedframe.py
@@ -491,11 +491,6 @@ def test_join_nested_with_flat_df_and_mismatched_index():
     assert_frame_equal(left_res, default_res)
 
     # Test still adding the nested frame in a "left" fashion but on the "new_index" column
-
-    # We currently don't support a list of columns for the 'on' argument
-    with pytest.raises(ValueError):
-        left_res_on = base.join_nested(nested, "nested", how="left", on=["new_index"])
-    # Instead we should pass a single column name, "new_index" which exists in both frames.
     left_res_on = base.join_nested(nested, "nested", how="left", on="new_index")
     assert "nested" in left_res_on.columns
     # Check that the index of the base layer is still being used
@@ -518,6 +513,10 @@ def test_join_nested_with_flat_df_and_mismatched_index():
             # Use an iloc
             assert left_res_on.iloc[i]["nested"] is None
             assert join_idx not in left_res_on["nested"].explode().index
+
+    # Single-element list is equivalent to passing the column name as a string
+    left_res_on_list = base.join_nested(nested, "nested", how="left", on=["new_index"])
+    assert_frame_equal(left_res_on_list, left_res_on)
 
     # Test adding the nested frame in a "right" fashion, where the index of the "right"
     # frame (our nested layer) is preserved
@@ -648,6 +647,65 @@ def test_join_nested_with_flat_df_and_mismatched_index():
     # Since we have confirmed that the "nex_index" column was the intersection that we expected
     # we know that none of the joined values should be none
     assert not inner_res_on.isnull().values.any()
+
+
+def test_join_nested_with_multi_column_on():
+    """Test that join_nested can use a list of columns as a join key"""
+
+    base = NestedFrame(data={"a": [1, 1, 2, 2, 3, 3], "b": [4, 5, 4, 5, 4, 5], "d": [1, 2, 3, 4, 5, 6]})
+
+    nested = pd.DataFrame(
+        data={
+            "a": [1, 1, 2, 2, 3, 3, 3],
+            "b": [4, 4, 4, 5, 5, 5, 6],
+            "c": [1, 2, 3, 4, 5, 6, 7],
+        }
+    )
+
+    # left (default): all base rows kept
+    left = base.join_nested(nested, "lc", on=["a", "b"])
+    assert len(left) == 6
+    # the original index is preserved
+    assert list(left.index) == list(base.index)
+    # the "on" columns are removed from the nested structure
+    assert "a" in left.columns
+    assert "b" in left.columns
+    assert "a" not in left["lc"].nest.columns
+    assert "b" not in left["lc"].nest.columns
+    # the data was joined correctly for each (a,b) pair
+    assert list(left.iloc[0]["lc"]["c"]) == [1, 2]  # matches for (1,4)
+    assert left.iloc[1]["lc"] is None  # no matches for (1,5)
+    assert list(left.iloc[2]["lc"]["c"]) == [3]  # matches for (2,4)
+    assert list(left.iloc[3]["lc"]["c"]) == [4]  # matches for (2,5)
+    assert left.iloc[4]["lc"] is None  # no matches for (3,4)
+    assert list(left.iloc[5]["lc"]["c"]) == [5, 6]  # matches for (3,5)
+
+    # inner: similar to left, but has only base rows with a nested match
+    inner = base.join_nested(nested, "lc", on=["a", "b"], how="inner")
+    assert list(inner.index) == [0, 2, 3, 5]
+    pd.testing.assert_frame_equal(left[~left["lc"].isna()], inner)
+
+    # right: all nested rows are kept
+    right = base.join_nested(nested, "lc", on=["a", "b"], how="right")
+    assert len(right) == 5
+    # (a,b) pair (3,6) is in nested but in not base
+    unmatched = right[(right["a"] == 3) & (right["b"] == 6)]
+    assert len(unmatched) == 1
+    assert list(unmatched.iloc[0]["lc"]["c"]) == [7]
+    # unmatched base rows get NaN base cols
+    assert pd.isna(unmatched.iloc[0]["d"])
+
+    # outer: union of both
+    outer = base.join_nested(nested, "lc", on=["a", "b"], how="outer")
+    assert len(outer) == 7
+    # unmatched base rows get None nested
+    unmatched_base = outer[(outer["a"] == 1) & (outer["b"] == 5)]
+    assert unmatched_base.iloc[0]["lc"] is None
+    unmatched_base2 = outer[(outer["a"] == 3) & (outer["b"] == 4)]
+    assert unmatched_base2.iloc[0]["lc"] is None
+    # unmatched nested rows get NaN base cols
+    unmatched_nested = outer[(outer["a"] == 3) & (outer["b"] == 6)]
+    assert pd.isna(unmatched_nested.iloc[0]["d"])
 
 
 def test_join_nested_with_series():


### PR DESCRIPTION
Allow `join_nested` on multiple columns. 

After some discussion with Kostya, it seems like the behavior provided by pandas join for multiple columns is already the intended behavior. If the user provides a multi-indexed dataframe to join nested the index is preserved and the data is merged on to the composite key (e.g. ["obj_id","passband"]).

This PR removes the exception raised when users pass a list to the `on` argument, updates the docstrings, and adds an example to the loading data docs page.

## Code Quality
- [X] I have read the Contribution Guide and agree to the Code of Conduct
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation