### PR TITLE
Enable 'print' lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ select = [
     "D419",
     # Numpy v2.0 compatibility
     "NPY201",
+    # flake8-print
+    "T201",
 ]
 ignore = [
     "UP006", # Allow non standard library generics in type hints


### PR DESCRIPTION
Testing 'print' lint (errors for print function usage) before adding it to PPT