### PR TITLE
Fix to_parquet/read_parquet for all-null nested fields (#507)

### DIFF
--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
+from pathlib import Path
 from typing import Literal
 
 import numpy as np
@@ -15,6 +16,7 @@ from pandas.api.extensions import no_default
 from pandas.core.computation.eval import Expr, ensure_scope
 from pandas.core.dtypes.common import is_bool_dtype
 from pandas.core.dtypes.inference import is_list_like
+from upath import UPath
 
 from nested_pandas.nestedframe.expr import (
     _identify_aliases,
@@ -2297,7 +2299,7 @@ class NestedFrame(pd.DataFrame):
         # Otherwise, return the results as a new NestedFrame
         return results_nf
 
-    def to_pandas(self, list_struct=False, large_list=False) -> pd.DataFrame:
+    def to_pandas(self, list_struct: bool = False, large_list: bool = False) -> pd.DataFrame:
         """Convert to an ordinal pandas DataFrame, with no NestedDtype series.
 
         NestedDtype is cast to pd.ArrowDtype
@@ -2305,9 +2307,10 @@ class NestedFrame(pd.DataFrame):
         Parameters
         ----------
         list_struct: bool
-            If True, cast nested columns to pandas struct-list arrow extension
-            array columns. If False (default), cast nested columns to
-            list-struct array columns.
+            Layout for the nested columns. If False (default), cast each nested
+            column to a struct-of-lists (``struct<field: list<...>, ...>``)
+            arrow extension array. If True, cast it to a list-of-structs
+            (``list<struct<...>>``) arrow extension array.
         large_list : bool
             If False (default), use regular ``list_`` (int32 offsets). Set to
             True to use ``large_list`` (int64 offsets), which is required when
@@ -2336,7 +2339,52 @@ class NestedFrame(pd.DataFrame):
             df[col] = df[col].array.to_arrow_ext_array(list_struct=list_struct, large_list=large_list)
         return df
 
-    def to_parquet(self, path, large_list=False, **kwargs) -> None:
+    def to_pyarrow(self, *, list_struct: bool = False, large_list: bool = False) -> pa.Table:
+        """Convert the NestedFrame into a pyarrow Table.
+
+        This is the counterpart of :func:`nested_pandas.from_pyarrow`.
+
+        Parameters
+        ----------
+        list_struct: bool
+            Layout for the nested columns. If False (default), pack each nested
+            column as a struct-of-lists (``struct<field: list<...>, ...>``). If
+            True, pack it as a list-of-structs (``list<struct<...>>``).
+        large_list : bool
+            If False (default), use regular ``list_`` (int32 offsets). Set to
+            True to use ``large_list`` (int64 offsets), which is required when
+            the total number of nested elements across all rows exceeds
+            ``2**31 - 1``.
+
+        Returns
+        -------
+        pyarrow.Table
+
+        Examples
+        --------
+        >>> from nested_pandas.datasets import generate_data
+        >>> nf = generate_data(5, 5, seed=1)
+        >>> table = nf.to_pyarrow()
+        """
+        df = self.to_pandas(list_struct=list_struct, large_list=large_list)
+
+        # This is potentially not zero-copy
+        # Note: Without pandas metadata, index writing is not as robust set
+        # preserve_index=None for best behavior but index will generally
+        # need to be set manually on load
+        table = pa.Table.from_pandas(df, preserve_index=None)
+
+        # Drop pandas metadata so NestedDtypes are not re-derived on read.
+        # We intentionally do *not* rebuild the schema with ``table.cast`` here:
+        # casting a ``list<null>`` field (an all-null nested column) triggers an
+        # upstream pyarrow bug that corrupts the list offsets:
+        # https://github.com/apache/arrow/issues/43838
+        # Dropping the schema-level metadata directly achieves the same goal safely.
+        return table.replace_schema_metadata(None)
+
+    def to_parquet(
+        self, path: str | Path | UPath, *, list_struct: bool = False, large_list: bool = False, **kwargs
+    ) -> None:
         """Creates parquet file(s) with the data of a NestedFrame, either
         as a single parquet file where each nested dataset is packed into its
         own column or as an individual parquet file for each layer.
@@ -2348,6 +2396,10 @@ class NestedFrame(pd.DataFrame):
         ----------
         path : str
             The path to the parquet file
+        list_struct: bool
+            Layout for the nested columns. If False (default), pack each nested
+            column as a struct-of-lists (``struct<field: list<...>, ...>``). If
+            True, pack it as a list-of-structs (``list<struct<...>>``).
         large_list : bool
             If False (default), use regular ``list_`` (int32 offsets). Set to
             True to use ``large_list`` (int64 offsets), which is required when
@@ -2364,21 +2416,9 @@ class NestedFrame(pd.DataFrame):
 
         Examples
         --------
-        >>> from nested_pandas.datasets.generation import generate_data
+        >>> from nested_pandas.datasets import generate_data
         >>> nf = generate_data(5,5, seed=1)
         >>> nf.to_parquet("nestedframe.parquet")  # doctest: +SKIP
         """
-        df = self.to_pandas(list_struct=False, large_list=large_list)
-
-        # Write through pyarrow
-        # This is potentially not zero-copy
-        # Note: Without pandas metadata, index writing is not as robust set
-        # preserve_index=None for best behavior but index will generally
-        # need to be set manually on load
-        table = pa.Table.from_pandas(df, preserve_index=None)
-
-        # Drop pandas metadata to make sure nesteddtypes are not preserved
-        # Do this by rebuilding the schema
-        table = table.cast(pa.schema([field for field in table.schema]))
-
+        table = self.to_pyarrow(list_struct=list_struct, large_list=large_list)
         return pq.write_table(table, path, **kwargs)

--- a/src/nested_pandas/nestedframe/core.py
+++ b/src/nested_pandas/nestedframe/core.py
@@ -2369,9 +2369,6 @@ class NestedFrame(pd.DataFrame):
         df = self.to_pandas(list_struct=list_struct, large_list=large_list)
 
         # This is potentially not zero-copy
-        # Note: Without pandas metadata, index writing is not as robust set
-        # preserve_index=None for best behavior but index will generally
-        # need to be set manually on load
         table = pa.Table.from_pandas(df, preserve_index=None)
 
         # Drop pandas metadata so NestedDtypes are not re-derived on read.

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -579,10 +579,7 @@ def _cast_struct_cols_to_nested(df: NestedFrame, reject_nesting: list[str], tabl
     rather than from the ``df`` columns produced by ``Table.to_pandas``.
     Converting a struct column that holds a ``null``-typed (all-null) field via
     ``types_mapper=pd.ArrowDtype`` corrupts it
-    (https://github.com/apache/arrow/issues/44881); building from the table
-    avoids the bug and preserves the exact field types (e.g. ``large_string``).
-    Since the table is still alive (see ``from_pyarrow``), this is as cheap as
-    reading from the ``df`` column would have been.
+    (https://github.com/apache/arrow/issues/44881).
     """
     for field in table.schema:
         if field.name in reject_nesting:

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -551,19 +551,19 @@ def from_pyarrow(
     elif isinstance(reject_nesting, str):
         reject_nesting = [reject_nesting]
 
-    # Convert to NestedFrame
-    # not zero-copy, but reduce memory pressure via the self_destruct kwarg
-    # https://arrow.apache.org/docs/python/pandas.html#reducing-memory-use-in-table-to-pandas
+    # Convert to a NestedFrame. With types_mapper=pd.ArrowDtype every column is
+    # backed by the table's Arrow buffers, so this is zero-copy and there is no
+    # need for the self_destruct memory optimization (which only helps the
+    # NumPy-conversion path).
     df = NestedFrame(
         table.to_pandas(
             types_mapper=pd.ArrowDtype,
             split_blocks=True,
-            self_destruct=True,
             ignore_metadata=not use_pandas_metadata,
         )
     )
-    # Attempt to cast struct columns to NestedDTypes
-    df = _cast_struct_cols_to_nested(df, reject_nesting)
+    # Replace struct columns with NestedExtensionArrays built from the table.
+    df = _cast_struct_cols_to_nested(df, reject_nesting, table)
 
     # If autocast_list is True, cast list columns to NestedDTypes
     if autocast_list:
@@ -572,28 +572,37 @@ def from_pyarrow(
     return df
 
 
-def _cast_struct_cols_to_nested(df, reject_nesting):
-    """cast struct columns to nested dtype"""
-    # Attempt to cast struct columns to NestedDTypes
-    for col, dtype in df.dtypes.items():
-        if col in reject_nesting:
+def _cast_struct_cols_to_nested(df: NestedFrame, reject_nesting: list[str], table: pa.Table) -> NestedFrame:
+    """Replace struct columns of ``df`` with nested columns built from ``table``.
+
+    The nested columns are constructed straight from the pyarrow ``table``
+    rather than from the ``df`` columns produced by ``Table.to_pandas``.
+    Converting a struct column that holds a ``null``-typed (all-null) field via
+    ``types_mapper=pd.ArrowDtype`` corrupts it
+    (https://github.com/apache/arrow/issues/44881); building from the table
+    avoids the bug and preserves the exact field types (e.g. ``large_string``).
+    Since the table is still alive (see ``from_pyarrow``), this is as cheap as
+    reading from the ``df`` column would have been.
+    """
+    for field in table.schema:
+        if field.name in reject_nesting:
             continue
 
-        if not NestedExtensionArray.is_input_pa_type_supported(dtype.pyarrow_dtype):
+        if not NestedExtensionArray.is_input_pa_type_supported(field.type):
             continue
 
         try:
             # Attempt to cast Struct to NestedDType
-            df[col] = NestedExtensionArray(pa.array(df[col]))
+            df[field.name] = NestedExtensionArray(table.column(field.name))
         except ValueError as err:
             # If cast fails, the struct likely does not fit nested-pandas
             # criteria for a valid nested column
             raise ValueError(
-                f"Column '{col}' is a Struct, but an attempt to cast it to a NestedDType failed. "
+                f"Column '{field.name}' is a Struct, but an attempt to cast it to a NestedDType failed. "
                 "This is likely due to the struct not meeting the requirements for a nested column "
                 "(all fields should be equal length). To proceed, you may add the column to the "
                 "`reject_nesting` argument of the read_parquet function to skip the cast attempt:"
-                f" read_parquet(..., reject_nesting=['{col}'])"
+                f" read_parquet(..., reject_nesting=['{field.name}'])"
             ) from err
     return df
 

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -282,6 +282,78 @@ def test_to_parquet():
         assert_frame_equal(nf, nf2)
 
 
+@pytest.mark.parametrize("list_struct", [False, True])
+def test_to_pyarrow_list_struct_roundtrip(list_struct):
+    """to_pyarrow / to_parquet support both nested layouts and round-trip."""
+    # Source is already ArrowDtype-backed so flat-column dtypes round-trip too.
+    nf = read_parquet("tests/test_data/nested.parquet")
+    nested_col = nf.nested_columns[0]
+
+    # The requested layout is reflected in the table schema.
+    table = nf.to_pyarrow(list_struct=list_struct)
+    table.validate(full=True)  # the produced table must be structurally sound
+    nested_type = table.schema.field(nested_col).type
+    if list_struct:
+        assert pa.types.is_list(nested_type) or pa.types.is_large_list(nested_type)
+    else:
+        assert pa.types.is_struct(nested_type)
+
+    # In-memory and on-disk round-trips both reconstruct the NestedFrame.
+    assert_frame_equal(nf, from_pyarrow(table))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "layout.parquet")
+        nf.to_parquet(path, list_struct=list_struct)
+        pq.read_table(path).validate(full=True)  # the written file must be sound
+        assert_frame_equal(nf, read_parquet(path))
+
+
+def test_to_parquet_roundtrip_null_nested_field():
+    """Round-trip a nested column with an all-null (``null``-typed) field.
+
+    Regression test for https://github.com/lincc-frameworks/nested-pandas/issues/507:
+    ``list<null>`` fields tripped an upstream pyarrow bug both on write (via the
+    schema-rebuilding ``table.cast``) and on read (via ``Table.to_pandas``), which
+    corrupted the list offsets of the all-null field.
+    """
+    # Struct-of-lists with an all-null field ``n`` and uneven list lengths [1, 1, 2].
+    offsets = pa.array([0, 1, 2, 4], type=pa.int32())
+    struct = pa.StructArray.from_arrays(
+        [
+            pa.ListArray.from_arrays(offsets, pa.nulls(4, pa.null())),
+            pa.ListArray.from_arrays(offsets, pa.array([10, 20, 30, 40], pa.int64())),
+        ],
+        names=["n", "v"],
+    )
+    table = pa.table({"id": pa.array([1, 2, 3]), "nested": struct})
+    nf = from_pyarrow(table)
+
+    def assert_roundtrips(other):
+        assert nf.nested_columns == other.nested_columns == ["nested"]
+        assert nf["nested"].dtype == other["nested"].dtype
+        assert_frame_equal(nf.drop(columns="nested"), other.drop(columns="nested"))
+        # Compare the flattened nested data, including the all-null ``n`` field.
+        assert_frame_equal(
+            nf["nested"].nest.to_flat().reset_index(drop=True),
+            other["nested"].nest.to_flat().reset_index(drop=True),
+        )
+
+    # In-memory round-trip through the public pyarrow API (no schema metadata).
+    # ``validate(full=True)`` guards against silent corruption of the all-null
+    # field: the pyarrow bug produces an invalid array without raising, so a
+    # round-trip comparison alone would not reliably catch it.
+    round_tripped = nf.to_pyarrow()
+    round_tripped.validate(full=True)
+    assert round_tripped.schema.metadata is None
+    assert_roundtrips(from_pyarrow(round_tripped))
+
+    # Round-trip through a parquet file on disk.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "null_field.parquet")
+        nf.to_parquet(path)
+        pq.read_table(path).validate(full=True)  # the written file must be sound
+        assert_roundtrips(read_parquet(path))
+
+
 def test_pandas_read_parquet():
     """Test that pandas can read our serialized files"""
 


### PR DESCRIPTION
A NestedFrame with an all-null (null-typed) nested field crashed on to_parquet, and such data also failed to read back. The root cause is two open upstream pyarrow bugs in null-typed nested handling:

- casting a list<null> field corrupts its offsets (apache/arrow#43838), which broke the identity `table.cast` used in to_parquet to drop metadata;
- `Table.to_pandas(types_mapper=pd.ArrowDtype)` truncates a null-typed field (apache/arrow#44881), which broke the read path.

Rather than repair the corrupted arrays, avoid invoking the buggy ops:

- Add a public NestedFrame.to_pyarrow() (counterpart to from_pyarrow) that builds the table and drops pandas metadata via replace_schema_metadata instead of table.cast. to_parquet is now a thin wrapper over it.
- from_pyarrow builds nested columns straight from the (uncorrupted) pyarrow table column instead of the corrupted pd.ArrowDtype column. Dropped the now-pointless self_destruct (ArrowDtype conversion is zero-copy).

This PR fixes #507, but doesn't fix other potential problems with null-type casting.

Also:
- to_pyarrow/to_parquet accept list_struct to choose the on-disk layout (struct-of-lists vs list-of-structs), like to_pandas.
- Fix the backwards list_struct layout wording in the to_pandas docstring.
- Add type annotations to the touched methods and use the short datasets.generate_data import form in the new doctests.