### PR TITLE
Don't use fsspec when reading local files

### DIFF
--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -220,21 +220,21 @@ def _read_parquet_into_table(
 ) -> pa.Table:
     """Reads parquet file(s) from path and returns a pyarrow table.
 
-    For single Parquet file paths, we want to use
-    `fsspec.parquet.open_parquet_file`.  But for any other usage
-    (which includes file-like objects, local directories and lists
-    thereof), we want to defer to `pq.read_table`.
+    For single remote Parquet file paths, we want to use
+    `fsspec.parquet.open_parquet_file`. Remote directories are handled
+    separately via `_read_remote_parquet_directory`. For everything local
+    (files and directories alike), as well as file-like objects and lists
+    thereof, we want to defer to `pq.read_table`, which can read local
+    directories directly.
 
-    NOTE: the test for _is_local_dir is sufficient, because we're
-    preserving a path to pq.read_table, which can read local
-    directories, but not remote directories. Remote directories
-    are supported separately via _read_parquet_directory.
-    We don't support HTTP "directories", because 1) calling .is_dir()
-    may be very expensive, because it downloads content first,
-    2) because .iter_dir() is likely to return a lot of "junk"
-    besides of the actual parquet files.
+    NOTE: local paths are routed straight to `pq.read_table` via `_is_local_path`,
+    without ever checking whether they're a file or a directory, since
+    `pq.read_table` handles both natively. We don't support HTTP
+    "directories", because 1) calling .is_dir() may be very expensive, because
+    it downloads content first, 2) because .iter_dir() is likely to return a
+    lot of "junk" besides of the actual parquet files.
     """
-    if isinstance(data, str | Path | UPath) and not _is_local_dir(path_to_data := UPath(data), is_dir=is_dir):
+    if isinstance(data, str | Path | UPath) and not _is_local_path(path_to_data := UPath(data)):
         storage_options = _get_storage_options(path_to_data)
         filesystem = kwargs.get("filesystem")
         if not filesystem:
@@ -310,20 +310,9 @@ def _validate_structs_from_schema(data, columns=None, filesystem=None):
                             )
 
 
-def _is_local_dir(upath: UPath, is_dir: bool | None) -> bool:
-    """Returns True if the given path refers to a local directory.
-
-    It's necessary to have this function, rather than simply checking
-    ``UPath(p).is_dir()``, because ``UPath.is_dir`` can be quite
-    expensive in the case of a remote file path that isn't a directory.
-    """
-
-    # For non-local filesystems, return False right away
-    if upath.protocol not in ("", "file"):
-        return False
-    # For local filesystems, check is_dir if provided, otherwise use upath.is_dir()
-    else:
-        return upath.is_dir() if is_dir is None else is_dir
+def _is_local_path(upath: UPath) -> bool:
+    """Returns True if the given path refers to a local file or directory."""
+    return upath.protocol in ("", "file")
 
 
 def _is_remote_dir(orig_data: str | Path | UPath, upath: UPath, is_dir: bool | None) -> bool:
@@ -466,6 +455,9 @@ def _transform_read_parquet_data_arg(data):
         return data, None
     # Check if `data` is a UPath and use it
     if isinstance(data, UPath):
+        # Local filesystem: never hand off to fsspec, just use the plain path.
+        if data.protocol in ("", "file"):
+            return data.path, None
         return data.path, data.fs
     # Check if `data` is a Path (Path is a superclass for UPath, so this order of checks)
     if isinstance(data, Path):

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 
 import fsspec.implementations.http
-import fsspec.implementations.local
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -438,7 +437,7 @@ def test__transform_read_parquet_data_arg():
     assert _transform_read_parquet_data_arg(Path(local_path)) == (Path(local_path), None)
 
     local_upath = UPath(local_path)
-    assert _transform_read_parquet_data_arg(local_upath) == (local_path, local_upath.fs)
+    assert _transform_read_parquet_data_arg(local_upath) == (local_path, None)
 
     s3_path = "s3://nasa-irsa-euclid-q1/contributed/q1/merged_objects/hats/euclid_q1_merged_objects-hats/dataset/Norder=3/Dir=0/Npix=334/part0.snappy.parquet"
     path, fs = _transform_read_parquet_data_arg(s3_path)
@@ -459,7 +458,7 @@ def test__transform_read_parquet_data_arg():
     local_upaths = list(UPath("tests/test_data").glob("*.parquet"))
     paths, fs = _transform_read_parquet_data_arg(local_upaths)
     assert paths == [up.path for up in local_upaths]
-    assert isinstance(fs, fsspec.implementations.local.LocalFileSystem)
+    assert fs is None
 
     with pytest.raises(ValueError):
         _transform_read_parquet_data_arg(
@@ -525,27 +524,13 @@ def test__get_storage_options():
     assert storage_opts.get("block_size") != FSSPEC_BLOCK_SIZE
 
 
-def test__is_local_dir():
-    """Test the _is_local_dir function with various scenarios."""
-    from nested_pandas.nestedframe.io import _is_local_dir
+def test__is_local_path():
+    """Test the _is_local_path function with various scenarios."""
+    from nested_pandas.nestedframe.io import _is_local_path
 
-    # Local path that is a directory
-    local_dir = UPath("tests/test_data")
-    assert _is_local_dir(local_dir, is_dir=True) is True
-    assert _is_local_dir(local_dir, is_dir=False) is False
-    assert _is_local_dir(local_dir, is_dir=None) is True
-
-    # Local path that is a file
-    local_file = UPath("tests/test_data/nested.parquet")
-    assert _is_local_dir(local_file, is_dir=True) is True
-    assert _is_local_dir(local_file, is_dir=False) is False
-    assert _is_local_dir(local_file, is_dir=None) is False
-
-    # Remote path (should always return False)
-    remote_path = UPath("https://example.com/data.parquet")
-    assert _is_local_dir(remote_path, is_dir=True) is False
-    assert _is_local_dir(remote_path, is_dir=False) is False
-    assert _is_local_dir(remote_path, is_dir=None) is False
+    assert _is_local_path(UPath("tests/test_data")) is True
+    assert _is_local_path(UPath("tests/test_data/nested.parquet")) is True
+    assert _is_local_path(UPath("https://example.com/data.parquet")) is False
 
 
 def test__is_remote_dir():


### PR DESCRIPTION
Use `pq.read_table` with local paths directly, not through `fsspec.parquet`.

Fixes #521
