### PR TITLE
Use `datafusion` as an optional `read_parquet` engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
+    "datafusion>=43",  # adds parquet.schema_force_view_types
+    # datafusion requires it, and versions < 4 conflict with other stuff
+    "typing-extensions>=4.0.0; python_version < '3.13'",
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
     "pandas>=3,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.11"
 dependencies = [
     "datafusion>=43",  # adds parquet.schema_force_view_types
     # datafusion requires it, and versions < 4 conflict with other stuff
-    "typing-extensions>=4.0.0; python_version < '3.13'",
+    "typing-extensions>=4.5.0; python_version < '3.13'",
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
     "pandas>=3,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    "datafusion>=43",  # adds parquet.schema_force_view_types
-    # datafusion requires it, and versions < 4 conflict with other stuff
+    # datafusion is an optional dependency of `read_parquet(engine="datafusion")`
+    # typing-extensions versions < 4 conflict with other stuff
     "typing-extensions>=4.5.0; python_version < '3.13'",
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
@@ -42,6 +42,7 @@ dev = [
     "pre-commit", # Used to run checks before finalizing a git commit
     "pytest",
     "pytest-cov", # Used to report total code coverage
+    "datafusion", # Optional engine of read_parquet()
     "ruff", # Used for static linting of files
     "aiohttp",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
-    # datafusion is an optional dependency of `read_parquet(engine="datafusion")`
-    # typing-extensions versions < 4 conflict with other stuff
-    "typing-extensions>=4.5.0; python_version < '3.13'",
     "numpy>=2",
     # We use internal pd._libs.missing and experimental ArrowExtensionArray
     "pandas>=3,<4",
@@ -42,7 +39,9 @@ dev = [
     "pre-commit", # Used to run checks before finalizing a git commit
     "pytest",
     "pytest-cov", # Used to report total code coverage
-    "datafusion", # Optional engine of read_parquet()
+    "datafusion>=43", # Optional engine of read_parquet()
+    # typing-extensions versions < 4 conflict with other stuff
+    "typing-extensions>=4.5.0; python_version < '3.13'",
     "ruff", # Used for static linting of files
     "aiohttp",
     "requests",

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -41,7 +41,7 @@ def read_parquet(
     autocast_list: bool = False,
     is_dir: bool | None = None,
     use_pandas_metadata: bool = True,
-    engine: Literal["pyarrow", "datafusion", "auto"] = "auto",
+    engine: Literal["pyarrow", "datafusion"] = "pyarrow",
     **kwargs,
 ) -> NestedFrame:
     """Load a parquet object from a file path into a NestedFrame.
@@ -92,10 +92,10 @@ def read_parquet(
         file's schema when constructing the NestedFrame (e.g. restoring the
         index and column dtypes). This matches the default behavior of
         pd.read_parquet. Set to False to ignore the metadata.
-    engine: "pyarrow", "datafusion" or "auto", default="auto"
+    engine: "pyarrow" or "datafusion", default="pyarrow"
         Which library to use for the parquet read.
 
-        - "pyarrow" uses `fsspec.parquet` (remote paths only) and
+        - "pyarrow" (default) uses `fsspec.parquet` (remote paths only) and
           `pyarrow.parquet.read_table`. It reads a nested column whole even
           when a single sub-column is asked for, and it applies `filters`
           after reading the row groups they select, so it is not the best
@@ -105,18 +105,16 @@ def read_parquet(
           pushes both down into the parquet reader, so it reads a nested
           sub-column without its siblings, and a filter without the pages it
           excludes. It costs a few milliseconds of query planning, which
-          dominates for small files or a handful of small columns, and it
-          reads a single local path only: for remote paths, file-like
-          objects and lists of paths use "pyarrow".
-        - "auto" (default) uses "datafusion" for the reads it can serve and
-          is faster at, and "pyarrow" for everything else. See
-          `get_the_best_engine` for the exact rule.
+          dominates for small files or a handful of small columns. It reads a
+          single local, HTTPS, or S3 path, the last with `key` and `secret`
+          in its `storage_options`, and raises for anything else it cannot
+          serve.
     kwargs: dict
         Keyword arguments passed to `pyarrow.parquet.read_table`, of which
         the "datafusion" engine accepts `filters` and `filesystem` (a local
         one), plus a `schema` of its own. `filters` must be in the
-        list-of-tuples format there, and a `pyarrow.compute.Expression`
-        selects the "pyarrow" engine under `engine="auto"`.
+        list-of-tuples format there, a `pyarrow.compute.Expression` is not
+        supported by the "datafusion" engine.
 
     Returns
     -------
@@ -166,8 +164,8 @@ def read_parquet(
 
     """
 
-    if engine not in ("pyarrow", "datafusion", "auto"):
-        raise ValueError(f"Invalid engine: '{engine}', must be 'pyarrow', 'datafusion' or 'auto'")
+    if engine not in ("pyarrow", "datafusion"):
+        raise ValueError(f"Invalid engine: '{engine}', must be 'pyarrow' or 'datafusion'")
 
     _validate_filter_columns(kwargs.get("filters"))
 
@@ -268,7 +266,8 @@ def _read_parquet_into_table(
     """
     if isinstance(data, str | Path | UPath) and not _is_local_path(path_to_data := UPath(data)):
         if engine == "datafusion":
-            raise ValueError(_datafusion_unsupported_reason(data, columns=columns, **kwargs))
+            # Raises ValueError
+            return _datafusion_read_table(path_to_data, columns=columns, **kwargs)
 
         storage_options = _get_storage_options(path_to_data)
         filesystem = kwargs.get("filesystem")
@@ -306,14 +305,6 @@ def _read_parquet_into_table(
 
 
 def _validate_filter_columns(filters) -> None:
-    """Reject filters on a nested sub-column, which neither engine can apply.
-
-    pyarrow's DNF filters have no way to name a nested field at all, and while
-    datafusion resolves "nested.t" it can only compare the whole list of a row
-    against the scalar. Both fail, with unrelated messages, so say it up front.
-
-    Anything else about the format is left to the engines, which report it.
-    """
     if filters is None or isinstance(filters, pc.Expression) or not isinstance(filters, list):
         return
     # Both [(column, op, value), ...] and [[(column, op, value), ...], ...]
@@ -333,92 +324,89 @@ def _validate_filter_columns(filters) -> None:
                 )
 
 
-def _datafusion_unsupported_reason(
+@lru_cache(maxsize=128)
+def _build_http_store(base_url: str):
+    from datafusion.object_store import Http
+
+    return Http(base_url)
+
+
+@lru_cache(maxsize=128)
+def _build_s3_store(bucket: str, region: str | None, key: str, secret: str, endpoint: str | None):
+    from datafusion.object_store import AmazonS3
+
+    return AmazonS3(
+        bucket_name=bucket,
+        region=region,
+        access_key_id=key,
+        secret_access_key=secret,
+        endpoint=endpoint,
+    )
+
+
+def _datafusion_object_store(path: UPath):
+    options = dict(path.storage_options)
+
+    # Only https: datafusion-python doesn't support http yet
+    if path.protocol == "https":
+        if options:
+            raise ValueError(
+                f"The 'datafusion' engine cannot pass these HTTPS storage options on to its "
+                f"object store: {sorted(options)}; use engine='pyarrow' to read with them."
+            )
+        base_url = f"{path.drive}/"
+        return base_url, _build_http_store(base_url)
+
+    if path.protocol == "s3":
+        key = options.pop("key", None)
+        secret = options.pop("secret", None)
+        endpoint = options.pop("endpoint_url", None)
+        client_kwargs = options.pop("client_kwargs", None) or {}
+        region = client_kwargs.get("region_name")
+        if key is None or secret is None:
+            raise ValueError(
+                "The 'datafusion' engine needs both 'key' and 'secret' in the S3 path's "
+                "storage_options: it cannot read credentials from the environment, nor "
+                "make an anonymous request; use engine='pyarrow' for either."
+            )
+        if leftover := sorted(options) + sorted(set(client_kwargs) - {"region_name"}):
+            raise ValueError(
+                f"The 'datafusion' engine cannot pass these S3 storage options on to its "
+                f"object store: {leftover}; use engine='pyarrow' to read with them."
+            )
+        bucket = path.drive
+        return f"s3://{bucket}/", _build_s3_store(bucket, region, key, secret, endpoint)
+
+    raise ValueError(
+        f"The 'datafusion' engine cannot build an object store for this '{path.protocol}' "
+        "path, it reads local paths, HTTPS, and S3 with an explicit key and secret; "
+        "use engine='pyarrow' for anything else."
+    )
+
+
+def _check_datafusion_support(
     data, *, columns=None, filesystem=None, filters=None, schema=None, use_threads=True, **kwargs
-) -> str | None:
-    """Why the 'datafusion' engine cannot serve this read, None if it can.
-
-    The named arguments are the ones the engine supports, so anything left in
-    `kwargs` rules it out. `columns` and `schema` it takes as they come, the
-    rest are checked below.
-
-    The returned string is a complete sentence, suitable for an error message.
-    """
-    # datafusion reads through its own object store layer, it has no way to consume
-    # a Python file-like object, a list of paths, or a bytes buffer
+) -> None:
     if not isinstance(data, str | Path | UPath):
-        return (
+        raise ValueError(
             f"The 'datafusion' engine supports a single path only, got '{type(data).__name__}'; "
             "use engine='pyarrow' for file-like objects and lists of paths."
         )
-    # Covers both UPath and plain "https://..." / "s3://..." strings
     if not _is_local_path(path := UPath(data)):
-        return (
-            f"The 'datafusion' engine supports local paths only, got a '{path.protocol}' path; "
-            "use engine='pyarrow' for remote files."
-        )
-    # A local filesystem is what datafusion would use anyway, anything else it cannot use
+        _datafusion_object_store(path)
     if filesystem is not None and not isinstance(filesystem, pa.fs.LocalFileSystem):
-        return f"The '{type(filesystem).__name__}' filesystem is not supported by the 'datafusion' engine."
-    # There is no simple way to introspect PyArrow expression objects
+        raise ValueError(
+            f"The '{type(filesystem).__name__}' filesystem is not supported by the 'datafusion' engine."
+        )
     if isinstance(filters, pc.Expression):
-        return (
+        raise ValueError(
             "PyArrow Expression 'filters' are not supported by the 'datafusion' engine, "
             "use the list-of-tuples format instead: [(column, op, value), ...]."
         )
-    # datafusion always runs on its own thread pool, there is no way to turn that off
     if not use_threads:
-        return "'use_threads=False' is not supported by the 'datafusion' engine."
+        raise ValueError("'use_threads=False' is not supported by the 'datafusion' engine.")
     if kwargs:
-        return f"These arguments are not supported by the 'datafusion' engine: {sorted(kwargs)}."
-    return None
-
-
-def get_the_best_engine(
-    data: str | Path | UPath | bytes,
-    columns: list[str] | None = None,
-    filesystem: pa.fs.FileSystem | None = None,
-    filters: pc.Expression | list[tuple] | list[list[tuple]] | None = None,
-    **kwargs,
-) -> Literal["pyarrow", "datafusion"]:
-    """Pick the engine `read_parquet` should use for the given read.
-
-    "datafusion" is chosen only when it can serve the read at all, and when the
-    read has the shape it is actually better at: a filter, or a partial load of
-    a nested column, where it prunes I/O that pyarrow would do. Otherwise
-    "pyarrow" wins, because datafusion adds a few milliseconds of query planning.
-
-    Parameters
-    ----------
-    data : str, Path, UPath, bytes, file-like object, or list of these
-        The parquet source, same as `read_parquet`'s `data`.
-    columns : list of str, optional
-        Columns to load, sub-columns of nested columns are given with a dot,
-        e.g. "nested.flux".
-    filesystem : pyarrow.fs.FileSystem, optional
-        Filesystem to read the data with.
-    filters : pyarrow.compute.Expression, or list of tuples, or list of lists of tuples, optional
-        Row filters, in either of the formats `pyarrow.parquet.read_table` accepts.
-    **kwargs
-        Other keyword arguments `read_parquet` would pass to the reader. Any
-        argument datafusion has no equivalent for rules datafusion out.
-
-    Returns
-    -------
-    {"pyarrow", "datafusion"}
-        Name of the engine to use.
-    """
-    if (
-        _datafusion_unsupported_reason(
-            data, columns=columns, filesystem=filesystem, filters=filters, **kwargs
-        )
-        is not None
-    ):
-        return "pyarrow"
-    # Without filters and without nested sub-columns there is nothing for datafusion to prune
-    if filters is None and (columns is None or all("." not in column for column in columns)):
-        return "pyarrow"
-    return "datafusion"
+        raise ValueError(f"These arguments are not supported by the 'datafusion' engine: {sorted(kwargs)}.")
 
 
 def _pyarrow_read_table(data, *, columns=None, filesystem=None, **kwargs):
@@ -470,7 +458,7 @@ def _datafusion_read_table(
     -------
     pyarrow.Table
     """
-    reason = _datafusion_unsupported_reason(
+    _check_datafusion_support(
         data,
         columns=columns,
         filesystem=filesystem,
@@ -479,12 +467,20 @@ def _datafusion_read_table(
         use_threads=use_threads,
         **kwargs,
     )
-    if reason is not None:
-        raise ValueError(reason)
 
-    df = _datafusion_session_context().read_parquet(
+    context = _datafusion_session_context()
+    path = UPath(data)
+    if _is_local_path(path):
         # UPath.path drops the "file://" prefix, which DataFusion doesn't understand
-        UPath(data).path,
+        source = path.path
+    else:
+        # The check above already established that we can build one
+        base_url, store = _datafusion_object_store(path)
+        context.register_object_store(base_url, store)
+        source = str(path)
+
+    df = context.read_parquet(
+        source,
         skip_metadata=False,
         schema=schema,
     )
@@ -494,15 +490,12 @@ def _datafusion_read_table(
         df = df.filter(_datafusion_filters_to_expr(filters))
 
     if columns is not None:
-        # DataFusion requires the projected names to be unique, while pyarrow happily
-        # returns two "band" columns for columns=["nested.band", "lincc.band"]. Project
-        # to positional names and put the pyarrow ones back afterwards.
+        # DataFusion requires the projected names to be unique. Project
+        # to positional names and put the pyarrow ones back afterward.
         try:
             df = df.select(
                 *(_datafusion_column_expr(column).alias(f"__npd_{i}") for i, column in enumerate(columns))
             )
-        # DataFusion raises a bare Exception when a sub-column is requested from a
-        # list-of-structs column, give the same helpful message the pyarrow engine gives.
         except Exception as e:
             if any("." in column for column in columns):
                 try:
@@ -514,7 +507,6 @@ def _datafusion_read_table(
     table = df.to_arrow_table()
 
     if columns is not None:
-        # Be explicit about the output names, DataFusion may rename duplicates.
         table = table.rename_columns([column.split(".")[-1] for column in columns])
 
     return table
@@ -540,11 +532,6 @@ DATAFUSION_SESSION_SETTINGS = {
 
 @lru_cache(maxsize=1)
 def _datafusion_session_context():
-    """A single DataFusion session context, shared by all reads.
-
-    It is cached because the context also caches parquet footer metadata across
-    queries (`datafusion.runtime.metadata_cache_limit`, 50 MB by default).
-    """
     from datafusion import SessionConfig, SessionContext
 
     config = SessionConfig()
@@ -554,11 +541,6 @@ def _datafusion_session_context():
 
 
 def _datafusion_column_expr(column: str):
-    """Build a DataFusion expression for a possibly nested column name.
-
-    "nested.flux" becomes a struct field access aliased to "flux", the name
-    `pyarrow.parquet.read_table(columns=["nested.flux"])` gives it.
-    """
     from datafusion import col as df_col
 
     name, *sub_fields = column.split(".")
@@ -571,11 +553,6 @@ def _datafusion_column_expr(column: str):
 
 
 def _datafusion_filters_to_expr(filters):
-    """Convert pyarrow's DNF `filters` into a single DataFusion expression.
-
-    [(column, op, value), ...] is a conjunction, [[(column, op, value), ...], ...]
-    is a disjunction of conjunctions.
-    """
     from datafusion import functions as df_functions
     from datafusion import literal as df_literal
 
@@ -642,9 +619,6 @@ _DATAFUSION_FILTER_OPS = {
 
 def _read_table_with_partial_load_check(data, *, columns=None, filesystem=None, engine: str, **kwargs):
     """Read a pyarrow table with partial load check for nested structures"""
-    if engine == "auto":
-        engine = get_the_best_engine(data, columns=columns, filesystem=filesystem, **kwargs)
-
     if engine == "pyarrow":
         return _pyarrow_read_table(data, columns=columns, filesystem=filesystem, **kwargs)
     elif engine == "datafusion":

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import warnings
+from functools import lru_cache
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 import fsspec.parquet
 import pandas as pd
@@ -40,6 +41,7 @@ def read_parquet(
     autocast_list: bool = False,
     is_dir: bool | None = None,
     use_pandas_metadata: bool = True,
+    engine: Literal["pyarrow", "datafusion", "auto"] = "auto",
     **kwargs,
 ) -> NestedFrame:
     """Load a parquet object from a file path into a NestedFrame.
@@ -90,8 +92,31 @@ def read_parquet(
         file's schema when constructing the NestedFrame (e.g. restoring the
         index and column dtypes). This matches the default behavior of
         pd.read_parquet. Set to False to ignore the metadata.
+    engine: "pyarrow", "datafusion" or "auto", default="auto"
+        Which library to use for the parquet read.
+
+        - "pyarrow" uses `fsspec.parquet` (remote paths only) and
+          `pyarrow.parquet.read_table`. It reads a nested column whole even
+          when a single sub-column is asked for, and it applies `filters`
+          after reading the row groups they select, so it is not the best
+          choice for partial loads or selective filters.
+        - "datafusion" uses `datafusion.SessionContext.read_parquet`, and
+          translates `columns` and `filters` into a DataFusion query. It
+          pushes both down into the parquet reader, so it reads a nested
+          sub-column without its siblings, and a filter without the pages it
+          excludes. It costs a few milliseconds of query planning, which
+          dominates for small files or a handful of small columns, and it
+          reads a single local path only: for remote paths, file-like
+          objects and lists of paths use "pyarrow".
+        - "auto" (default) uses "datafusion" for the reads it can serve and
+          is faster at, and "pyarrow" for everything else. See
+          `get_the_best_engine` for the exact rule.
     kwargs: dict
-        Keyword arguments passed to `pyarrow.parquet.read_table`
+        Keyword arguments passed to `pyarrow.parquet.read_table`, of which
+        the "datafusion" engine accepts `filters` and `filesystem` (a local
+        one), plus a `schema` of its own. `filters` must be in the
+        list-of-tuples format there, and a `pyarrow.compute.Expression`
+        selects the "pyarrow" engine under `engine="auto"`.
 
     Returns
     -------
@@ -141,13 +166,18 @@ def read_parquet(
 
     """
 
+    if engine not in ("pyarrow", "datafusion", "auto"):
+        raise ValueError(f"Invalid engine: '{engine}', must be 'pyarrow', 'datafusion' or 'auto'")
+
+    _validate_filter_columns(kwargs.get("filters"))
+
     # Type convergence for reject_nesting
     if reject_nesting is None:
         reject_nesting = []
     elif isinstance(reject_nesting, str):
         reject_nesting = [reject_nesting]
 
-    table = _read_parquet_into_table(data, columns, is_dir=is_dir, **kwargs)
+    table = _read_parquet_into_table(data, columns=columns, is_dir=is_dir, engine=engine, **kwargs)
 
     # Resolve partial loading of nested structures
     # Using pyarrow to avoid naming conflicts from partial loading ("flux" vs "lc.flux")
@@ -214,8 +244,10 @@ def read_parquet(
 
 def _read_parquet_into_table(
     data: str | UPath | bytes,
+    *,
     columns: list[str] | None,
     is_dir: bool | None = None,
+    engine: str,
     **kwargs,
 ) -> pa.Table:
     """Reads parquet file(s) from path and returns a pyarrow table.
@@ -235,6 +267,9 @@ def _read_parquet_into_table(
     lot of "junk" besides of the actual parquet files.
     """
     if isinstance(data, str | Path | UPath) and not _is_local_path(path_to_data := UPath(data)):
+        if engine == "datafusion":
+            raise ValueError(_datafusion_unsupported_reason(data, columns=columns, **kwargs))
+
         storage_options = _get_storage_options(path_to_data)
         filesystem = kwargs.get("filesystem")
         if not filesystem:
@@ -252,22 +287,141 @@ def _read_parquet_into_table(
             fs=filesystem,
             engine="pyarrow",
         ) as parquet_file:
-            return _read_table_with_partial_load_check(parquet_file, columns=columns, **kwargs)
+            return _read_table_with_partial_load_check(
+                parquet_file, columns=columns, engine="pyarrow", **kwargs
+            )
 
     # All other cases, including file-like objects, directories, and
     # even lists of the foregoing.
 
     # If `filesystem` is specified - use it, passing it as part of **kwargs
     if kwargs.get("filesystem") is not None:
-        return _read_table_with_partial_load_check(data, columns=columns, **kwargs)
+        return _read_table_with_partial_load_check(data, columns=columns, engine=engine, **kwargs)
 
     # Otherwise convert with a special function
     data, filesystem = _transform_read_parquet_data_arg(data)
-    return _read_table_with_partial_load_check(data, columns=columns, filesystem=filesystem, **kwargs)
+    return _read_table_with_partial_load_check(
+        data, columns=columns, filesystem=filesystem, engine=engine, **kwargs
+    )
 
 
-def _read_table_with_partial_load_check(data, columns=None, filesystem=None, **kwargs):
-    """Read a pyarrow table with partial load check for nested structures"""
+def _validate_filter_columns(filters) -> None:
+    """Reject filters on a nested sub-column, which neither engine can apply.
+
+    pyarrow's DNF filters have no way to name a nested field at all, and while
+    datafusion resolves "nested.t" it can only compare the whole list of a row
+    against the scalar. Both fail, with unrelated messages, so say it up front.
+
+    Anything else about the format is left to the engines, which report it.
+    """
+    if filters is None or isinstance(filters, pc.Expression) or not isinstance(filters, list):
+        return
+    # Both [(column, op, value), ...] and [[(column, op, value), ...], ...]
+    for filter_ in filters:
+        conjunct = [filter_] if isinstance(filter_, tuple) else filter_
+        if not isinstance(conjunct, list | tuple):
+            continue
+        for term in conjunct:
+            if not isinstance(term, tuple) or len(term) != 3:
+                continue
+            column = term[0]
+            if isinstance(column, str) and "." in column:
+                raise ValueError(
+                    f"Cannot filter on '{column}': filtering on a sub-column of a nested "
+                    "column is not supported. Filter on a top-level column instead, or "
+                    "load the data and filter the NestedFrame afterwards."
+                )
+
+
+def _datafusion_unsupported_reason(
+    data, *, columns=None, filesystem=None, filters=None, schema=None, use_threads=True, **kwargs
+) -> str | None:
+    """Why the 'datafusion' engine cannot serve this read, None if it can.
+
+    The named arguments are the ones the engine supports, so anything left in
+    `kwargs` rules it out. `columns` and `schema` it takes as they come, the
+    rest are checked below.
+
+    The returned string is a complete sentence, suitable for an error message.
+    """
+    # datafusion reads through its own object store layer, it has no way to consume
+    # a Python file-like object, a list of paths, or a bytes buffer
+    if not isinstance(data, str | Path | UPath):
+        return (
+            f"The 'datafusion' engine supports a single path only, got '{type(data).__name__}'; "
+            "use engine='pyarrow' for file-like objects and lists of paths."
+        )
+    # Covers both UPath and plain "https://..." / "s3://..." strings
+    if not _is_local_path(path := UPath(data)):
+        return (
+            f"The 'datafusion' engine supports local paths only, got a '{path.protocol}' path; "
+            "use engine='pyarrow' for remote files."
+        )
+    # A local filesystem is what datafusion would use anyway, anything else it cannot use
+    if filesystem is not None and not isinstance(filesystem, pa.fs.LocalFileSystem):
+        return f"The '{type(filesystem).__name__}' filesystem is not supported by the 'datafusion' engine."
+    # There is no simple way to introspect PyArrow expression objects
+    if isinstance(filters, pc.Expression):
+        return (
+            "PyArrow Expression 'filters' are not supported by the 'datafusion' engine, "
+            "use the list-of-tuples format instead: [(column, op, value), ...]."
+        )
+    # datafusion always runs on its own thread pool, there is no way to turn that off
+    if not use_threads:
+        return "'use_threads=False' is not supported by the 'datafusion' engine."
+    if kwargs:
+        return f"These arguments are not supported by the 'datafusion' engine: {sorted(kwargs)}."
+    return None
+
+
+def get_the_best_engine(
+    data: str | Path | UPath | bytes,
+    columns: list[str] | None = None,
+    filesystem: pa.fs.FileSystem | None = None,
+    filters: pc.Expression | list[tuple] | list[list[tuple]] | None = None,
+    **kwargs,
+) -> Literal["pyarrow", "datafusion"]:
+    """Pick the engine `read_parquet` should use for the given read.
+
+    "datafusion" is chosen only when it can serve the read at all, and when the
+    read has the shape it is actually better at: a filter, or a partial load of
+    a nested column, where it prunes I/O that pyarrow would do. Otherwise
+    "pyarrow" wins, because datafusion adds a few milliseconds of query planning.
+
+    Parameters
+    ----------
+    data : str, Path, UPath, bytes, file-like object, or list of these
+        The parquet source, same as `read_parquet`'s `data`.
+    columns : list of str, optional
+        Columns to load, sub-columns of nested columns are given with a dot,
+        e.g. "nested.flux".
+    filesystem : pyarrow.fs.FileSystem, optional
+        Filesystem to read the data with.
+    filters : pyarrow.compute.Expression, or list of tuples, or list of lists of tuples, optional
+        Row filters, in either of the formats `pyarrow.parquet.read_table` accepts.
+    **kwargs
+        Other keyword arguments `read_parquet` would pass to the reader. Any
+        argument datafusion has no equivalent for rules datafusion out.
+
+    Returns
+    -------
+    {"pyarrow", "datafusion"}
+        Name of the engine to use.
+    """
+    if (
+        _datafusion_unsupported_reason(
+            data, columns=columns, filesystem=filesystem, filters=filters, **kwargs
+        )
+        is not None
+    ):
+        return "pyarrow"
+    # Without filters and without nested sub-columns there is nothing for datafusion to prune
+    if filters is None and (columns is None or all("." not in column for column in columns)):
+        return "pyarrow"
+    return "datafusion"
+
+
+def _pyarrow_read_table(data, *, columns=None, filesystem=None, **kwargs):
     try:
         return pq.read_table(data, columns=columns, filesystem=filesystem, **kwargs)
     except ArrowInvalid as e:
@@ -282,6 +436,221 @@ def _read_table_with_partial_load_check(data, columns=None, filesystem=None, **k
                 except ValueError as validation_error:
                     raise validation_error from e  # Chain the exceptions for better context
         raise e
+
+
+def _datafusion_read_table(
+    data, *, columns=None, filesystem=None, filters=None, schema=None, use_threads=True, **kwargs
+):
+    """Read local parquet file(s) into a pyarrow table with DataFusion.
+
+    Parameters
+    ----------
+    data : str or Path or UPath
+        Path to a local parquet file or to a directory of parquet files.
+    columns : list[str], optional
+        Columns to load, sub-columns of nested columns are given with a dot,
+        e.g. "nested.flux". The output table has the columns in the given
+        order, and a sub-column is named after the last component of its path,
+        which is what `pyarrow.parquet.read_table` does.
+    filesystem : pyarrow.fs.LocalFileSystem, optional
+        Only a local filesystem is accepted, which is what datafusion would use
+        anyway. Anything else raises.
+    filters : list[tuple] or list[list[tuple]], optional
+        Filters in pyarrow's DNF format, a list of tuples is a conjunction, a
+        list of lists of tuples is a disjunction of conjunctions.
+        `pyarrow.compute.Expression` is not supported.
+    schema : pyarrow.Schema, optional
+        Schema of the parquet file(s), inferred from the data if not given.
+    use_threads : bool, default True
+        Must be True, datafusion always runs on its own thread pool.
+    **kwargs
+        Not supported, must be empty.
+
+    Returns
+    -------
+    pyarrow.Table
+    """
+    reason = _datafusion_unsupported_reason(
+        data,
+        columns=columns,
+        filesystem=filesystem,
+        filters=filters,
+        schema=schema,
+        use_threads=use_threads,
+        **kwargs,
+    )
+    if reason is not None:
+        raise ValueError(reason)
+
+    df = _datafusion_session_context().read_parquet(
+        # UPath.path drops the "file://" prefix, which DataFusion doesn't understand
+        UPath(data).path,
+        skip_metadata=False,
+        schema=schema,
+    )
+
+    # Filter first: the filters may use columns we are not going to load.
+    if filters is not None:
+        df = df.filter(_datafusion_filters_to_expr(filters))
+
+    if columns is not None:
+        # DataFusion requires the projected names to be unique, while pyarrow happily
+        # returns two "band" columns for columns=["nested.band", "lincc.band"]. Project
+        # to positional names and put the pyarrow ones back afterwards.
+        try:
+            df = df.select(
+                *(_datafusion_column_expr(column).alias(f"__npd_{i}") for i, column in enumerate(columns))
+            )
+        # DataFusion raises a bare Exception when a sub-column is requested from a
+        # list-of-structs column, give the same helpful message the pyarrow engine gives.
+        except Exception as e:
+            if any("." in column for column in columns):
+                try:
+                    _validate_structs_from_schema(data, columns=columns)
+                except ValueError as validation_error:
+                    raise validation_error from e
+            raise
+
+    table = df.to_arrow_table()
+
+    if columns is not None:
+        # Be explicit about the output names, DataFusion may rename duplicates.
+        table = table.rename_columns([column.split(".")[-1] for column in columns])
+
+    return table
+
+
+# DataFusion session settings for every read.
+DATAFUSION_SESSION_SETTINGS = {
+    # Pruning and filter pushdown, `pushdown_filters` is off by default
+    "datafusion.execution.parquet.pushdown_filters": "true",
+    "datafusion.execution.parquet.reorder_filters": "true",
+    "datafusion.execution.parquet.enable_page_index": "true",
+    "datafusion.execution.parquet.bloom_filter_on_read": "true",
+    # Give `string`/`binary` like pyarrow, not the view types DataFusion prefers
+    "datafusion.execution.parquet.schema_force_view_types": "false",
+    # Default is 8192, which chunks the output table 15x more finely than pyarrow does
+    "datafusion.execution.batch_size": "131072",
+    # Scan in a single partition, so rows come back in file order like pyarrow's do.
+    # In parallel DataFusion splits the row groups of even a single file across
+    # partitions and the output order is not reproducible from run to run.
+    "datafusion.execution.target_partitions": "1",
+}
+
+
+@lru_cache(maxsize=1)
+def _datafusion_session_context():
+    """A single DataFusion session context, shared by all reads.
+
+    It is cached because the context also caches parquet footer metadata across
+    queries (`datafusion.runtime.metadata_cache_limit`, 50 MB by default).
+    """
+    from datafusion import SessionConfig, SessionContext
+
+    config = SessionConfig()
+    for key, value in DATAFUSION_SESSION_SETTINGS.items():
+        config = config.set(key, value)
+    return SessionContext(config)
+
+
+def _datafusion_column_expr(column: str):
+    """Build a DataFusion expression for a possibly nested column name.
+
+    "nested.flux" becomes a struct field access aliased to "flux", the name
+    `pyarrow.parquet.read_table(columns=["nested.flux"])` gives it.
+    """
+    from datafusion import col as df_col
+
+    name, *sub_fields = column.split(".")
+    # Quote the name: DataFusion lower-cases unquoted identifiers and treats a dot
+    # in them as a qualifier separator.
+    expr = df_col(f'"{name}"')
+    for sub_field in sub_fields:
+        expr = expr[sub_field]
+    return expr
+
+
+def _datafusion_filters_to_expr(filters):
+    """Convert pyarrow's DNF `filters` into a single DataFusion expression.
+
+    [(column, op, value), ...] is a conjunction, [[(column, op, value), ...], ...]
+    is a disjunction of conjunctions.
+    """
+    from datafusion import functions as df_functions
+    from datafusion import literal as df_literal
+
+    format_error = ValueError(
+        "filters format must be [(column, op, value), ...], or [[(column, op, value), ...], ...]"
+    )
+
+    if not isinstance(filters, list):
+        raise ValueError(
+            "filters must be a PyArrow Expression, list of tuples, or list of lists of tuples, or None; "
+            f"got '{type(filters)}'"
+        )
+    try:
+        element = filters[0][0]
+    except (IndexError, KeyError, TypeError) as e:
+        raise format_error from e
+    # Convert a single conjunction, list[tuple], into list[list[tuple]]
+    if not isinstance(element, tuple):
+        filters = [cast(list[tuple[str, str, object]], filters)]
+
+    def literal(value):
+        # DataFusion's literal() doesn't know numpy scalars, dates, and the like
+        try:
+            return df_literal(value)
+        except Exception:
+            return df_literal(pa.scalar(value))
+
+    disjunction = None
+    for conjunct in filters:
+        if not isinstance(conjunct, list) or len(conjunct) == 0:
+            raise format_error
+        conjunction = None
+        for filter_ in conjunct:
+            try:
+                column, op, value = filter_
+            except (TypeError, ValueError) as e:
+                raise format_error from e
+            expr = _datafusion_column_expr(column)
+            op = op.lower()
+            if op in ("in", "not in"):
+                expr = df_functions.in_list(expr, [literal(v) for v in value], negated=op == "not in")
+            else:
+                try:
+                    build_expr = _DATAFUSION_FILTER_OPS[op]
+                except KeyError as e:
+                    raise ValueError(f"Unsupported filter operator: '{op}'") from e
+                expr = build_expr(expr, literal(value))
+            conjunction = expr if conjunction is None else conjunction & expr
+        disjunction = conjunction if disjunction is None else disjunction | conjunction
+    return disjunction
+
+
+# Comparison operators of pyarrow's DNF filter format, "in" and "not in" are special-cased
+_DATAFUSION_FILTER_OPS = {
+    "=": lambda expr, value: expr == value,
+    "==": lambda expr, value: expr == value,
+    "!=": lambda expr, value: expr != value,
+    "<": lambda expr, value: expr < value,
+    "<=": lambda expr, value: expr <= value,
+    ">": lambda expr, value: expr > value,
+    ">=": lambda expr, value: expr >= value,
+}
+
+
+def _read_table_with_partial_load_check(data, *, columns=None, filesystem=None, engine: str, **kwargs):
+    """Read a pyarrow table with partial load check for nested structures"""
+    if engine == "auto":
+        engine = get_the_best_engine(data, columns=columns, filesystem=filesystem, **kwargs)
+
+    if engine == "pyarrow":
+        return _pyarrow_read_table(data, columns=columns, filesystem=filesystem, **kwargs)
+    elif engine == "datafusion":
+        return _datafusion_read_table(data, columns=columns, filesystem=filesystem, **kwargs)
+    else:
+        raise ValueError(f"Invalid engine: {engine}")
 
 
 def _validate_structs_from_schema(data, columns=None, filesystem=None):
@@ -401,7 +770,9 @@ def _read_remote_parquet_directory(
     tables = []
     for parquet_file in parquet_files:
         with parquet_file:
-            tables.append(_read_table_with_partial_load_check(parquet_file, columns=columns, **kwargs))
+            tables.append(
+                _read_table_with_partial_load_check(parquet_file, columns=columns, engine="pyarrow", **kwargs)
+            )
     return pa.concat_tables(tables)
 
 

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -261,7 +261,6 @@ def _read_parquet_into_table(
     """
     if isinstance(data, str | Path | UPath) and not _is_local_path(path_to_data := UPath(data)):
         if engine == "datafusion":
-            # Raises ValueError
             return _datafusion_read_table(path_to_data, columns=columns, **kwargs)
 
         storage_options = _get_storage_options(path_to_data)

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -507,11 +507,7 @@ def _datafusion_read_table(
                     raise validation_error from e
             raise
 
-    # Draining the partition streams in index order keeps the rows in the order they
-    # have in the input files, which `.collect_partitioned()` does not guarantee.
-    batches = [batch.to_pyarrow() for stream in df.execute_stream_partitioned() for batch in stream]
-    # The streams yield no batches at all when the filters exclude every row
-    table = pa.Table.from_batches(batches, schema=df.schema())
+    table = df.to_arrow_table()
 
     if columns is not None:
         table = table.rename_columns([column.split(".")[-1] for column in columns])
@@ -530,27 +526,19 @@ DATAFUSION_SESSION_SETTINGS = {
     "datafusion.execution.parquet.schema_force_view_types": "false",
     # Default is 8192, which chunks the output table 15x more finely than pyarrow does
     "datafusion.execution.batch_size": "131072",
-}
-
-# Work stealing lets an idle partition read the files of another one, which breaks the
-# row order `_datafusion_read_table` relies on. The option was added in datafusion v55,
-# and setting an unknown option panics, so it is applied to newer versions only.
-DATAFUSION_SESSION_SETTINGS_V55 = {
-    "datafusion.execution.enable_file_stream_work_stealing": "false",
+    # Scan in a single partition, so rows come back in file order like pyarrow's do.
+    # In parallel DataFusion splits the row groups of even a single file across
+    # partitions and the output order is not reproducible from run to run.
+    "datafusion.execution.target_partitions": "1",
 }
 
 
 @lru_cache(maxsize=1)
 def _datafusion_session_context():
     from datafusion import SessionConfig, SessionContext
-    from datafusion import __version__ as datafusion_version
-
-    settings = dict(DATAFUSION_SESSION_SETTINGS)
-    if int(datafusion_version.split(".")[0]) >= 55:
-        settings.update(DATAFUSION_SESSION_SETTINGS_V55)
 
     config = SessionConfig()
-    for key, value in settings.items():
+    for key, value in DATAFUSION_SESSION_SETTINGS.items():
         config = config.set(key, value)
     return SessionContext(config)
 

--- a/src/nested_pandas/nestedframe/io.py
+++ b/src/nested_pandas/nestedframe/io.py
@@ -100,15 +100,10 @@ def read_parquet(
           when a single sub-column is asked for, and it applies `filters`
           after reading the row groups they select, so it is not the best
           choice for partial loads or selective filters.
-        - "datafusion" uses `datafusion.SessionContext.read_parquet`, and
-          translates `columns` and `filters` into a DataFusion query. It
-          pushes both down into the parquet reader, so it reads a nested
-          sub-column without its siblings, and a filter without the pages it
-          excludes. It costs a few milliseconds of query planning, which
-          dominates for small files or a handful of small columns. It reads a
-          single local, HTTPS, or S3 path, the last with `key` and `secret`
-          in its `storage_options`, and raises for anything else it cannot
-          serve.
+        - "datafusion" may be very fast when a few rows and/or a few nested
+          subcolumns are selected. It reads a single local, HTTPS, or
+          S3 path, and raises for anything else. Needs the optional
+          `datafusion` package.
     kwargs: dict
         Keyword arguments passed to `pyarrow.parquet.read_table`, of which
         the "datafusion" engine accepts `filters` and `filesystem` (a local
@@ -387,6 +382,14 @@ def _datafusion_object_store(path: UPath):
 def _check_datafusion_support(
     data, *, columns=None, filesystem=None, filters=None, schema=None, use_threads=True, **kwargs
 ) -> None:
+    try:
+        import datafusion  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "The 'datafusion' engine requires the 'datafusion' package, install it with "
+            "`pip install datafusion`."
+        ) from e
+
     if not isinstance(data, str | Path | UPath):
         raise ValueError(
             f"The 'datafusion' engine supports a single path only, got '{type(data).__name__}'; "
@@ -504,7 +507,11 @@ def _datafusion_read_table(
                     raise validation_error from e
             raise
 
-    table = df.to_arrow_table()
+    # Draining the partition streams in index order keeps the rows in the order they
+    # have in the input files, which `.collect_partitioned()` does not guarantee.
+    batches = [batch.to_pyarrow() for stream in df.execute_stream_partitioned() for batch in stream]
+    # The streams yield no batches at all when the filters exclude every row
+    table = pa.Table.from_batches(batches, schema=df.schema())
 
     if columns is not None:
         table = table.rename_columns([column.split(".")[-1] for column in columns])
@@ -523,19 +530,27 @@ DATAFUSION_SESSION_SETTINGS = {
     "datafusion.execution.parquet.schema_force_view_types": "false",
     # Default is 8192, which chunks the output table 15x more finely than pyarrow does
     "datafusion.execution.batch_size": "131072",
-    # Scan in a single partition, so rows come back in file order like pyarrow's do.
-    # In parallel DataFusion splits the row groups of even a single file across
-    # partitions and the output order is not reproducible from run to run.
-    "datafusion.execution.target_partitions": "1",
+}
+
+# Work stealing lets an idle partition read the files of another one, which breaks the
+# row order `_datafusion_read_table` relies on. The option was added in datafusion v55,
+# and setting an unknown option panics, so it is applied to newer versions only.
+DATAFUSION_SESSION_SETTINGS_V55 = {
+    "datafusion.execution.enable_file_stream_work_stealing": "false",
 }
 
 
 @lru_cache(maxsize=1)
 def _datafusion_session_context():
     from datafusion import SessionConfig, SessionContext
+    from datafusion import __version__ as datafusion_version
+
+    settings = dict(DATAFUSION_SESSION_SETTINGS)
+    if int(datafusion_version.split(".")[0]) >= 55:
+        settings.update(DATAFUSION_SESSION_SETTINGS_V55)
 
     config = SessionConfig()
-    for key, value in DATAFUSION_SESSION_SETTINGS.items():
+    for key, value in settings.items():
         config = config.set(key, value)
     return SessionContext(config)
 

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -18,14 +18,15 @@ from nested_pandas import NestedFrame, read_parquet
 from nested_pandas.datasets import generate_data
 from nested_pandas.nestedframe.io import (
     FSSPEC_BLOCK_SIZE,
+    _check_datafusion_support,
     _columns_to_load,
     _datafusion_filters_to_expr,
+    _datafusion_object_store,
     _datafusion_read_table,
     _get_storage_options,
     _pyarrow_read_table,
     _transform_read_parquet_data_arg,
     from_pyarrow,
-    get_the_best_engine,
 )
 
 
@@ -972,52 +973,27 @@ def test_datafusion_read_table_unregistered_extension_type():
 
 
 @pytest.mark.parametrize(
-    "kwargs,expected",
-    [
-        # Nothing to prune, datafusion would only add its query planning overhead
-        ({}, "pyarrow"),
-        ({"columns": ["a", "flux"]}, "pyarrow"),
-        # A nested sub-column, which pyarrow cannot push down to the leaf
-        ({"columns": ["nested.flux"]}, "datafusion"),
-        ({"columns": ["a", "nested.flux"]}, "datafusion"),
-        # A filter, which datafusion pushes into the parquet reader
-        ({"filters": [("a", ">", 0.5)]}, "datafusion"),
-        ({"columns": ["a"], "filters": [("a", ">", 0.5)]}, "datafusion"),
-        # Reads datafusion cannot serve at all, despite their shape
-        ({"columns": ["nested.flux"], "filters": pc.field("a") > 0.5}, "pyarrow"),
-        ({"columns": ["nested.flux"], "read_dictionary": ["a"]}, "pyarrow"),
-        ({"columns": ["nested.flux"], "use_threads": False}, "pyarrow"),
-        # use_threads=True is what datafusion does anyway
-        ({"columns": ["nested.flux"], "use_threads": True}, "datafusion"),
-    ],
-)
-def test_get_the_best_engine(kwargs, expected):
-    """The engine is picked by what datafusion can do, and by what it is better at."""
-    assert get_the_best_engine("tests/test_data/nested.parquet", **kwargs) == expected
-
-
-@pytest.mark.parametrize(
     "data",
     [
-        # Remote paths, both as a plain string and as a UPath
+        # Remote paths we can build an object store for
         "https://example.com/nested.parquet",
-        "s3://bucket/nested.parquet",
         UPath("https://example.com/nested.parquet"),
-        # A list of paths and a file-like object
-        ["tests/test_data/nested.parquet", "tests/test_data/nested.parquet"],
-        io.BytesIO(b""),
+        UPath("s3://bucket/nested.parquet", key="AK", secret="SK"),
     ],
 )
-def test_get_the_best_engine_unsupported_data(data):
-    """Sources datafusion cannot read fall back to pyarrow, even for a read it wins at."""
-    assert get_the_best_engine(data, columns=["nested.flux"], filters=[("a", ">", 0.5)]) == "pyarrow"
+def test_datafusion_supported_remote(data):
+    """A remote path datafusion can build an object store for is not an error."""
+    _check_datafusion_support(data, columns=["nested.flux"])
 
 
 @pytest.mark.parametrize(
     "kwargs,match",
     [
-        ({"data": "https://example.com/nested.parquet"}, "local paths only"),
-        ({"data": UPath("s3://bucket/nested.parquet")}, "local paths only"),
+        # Remote paths we cannot build an object store for
+        ({"data": "http://example.com/nested.parquet"}, "cannot build an object store"),
+        ({"data": "gs://bucket/nested.parquet"}, "cannot build an object store"),
+        ({"data": UPath("s3://bucket/nested.parquet")}, "needs both 'key' and 'secret'"),
+        ({"data": UPath("s3://bucket/nested.parquet", anon=True)}, "needs both 'key' and 'secret'"),
         ({"data": ["a.parquet", "b.parquet"]}, "single path only"),
         ({"data": io.BytesIO(b"")}, "single path only"),
         ({"filesystem": fsspec.implementations.http.HTTPFileSystem()}, "not supported"),
@@ -1031,6 +1007,108 @@ def test_datafusion_read_table_unsupported(kwargs, match):
     kwargs = {"data": "tests/test_data/nested.parquet", **kwargs}
     with pytest.raises(ValueError, match=match):
         _datafusion_read_table(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "data,expected_base,expected_store",
+    [
+        # HTTPS needs no credentials, and registers under scheme://host/
+        ("https://data.example.com/a/b.parquet", "https://data.example.com/", "Http"),
+        (UPath("https://data.example.com/a/b.parquet"), "https://data.example.com/", "Http"),
+        # S3 with a key and a secret we can hand over directly
+        (UPath("s3://bucket/a.parquet", key="AK", secret="SK"), "s3://bucket/", "AmazonS3"),
+        (
+            UPath("s3://bucket/a.parquet", key="AK", secret="SK", endpoint_url="http://e"),
+            "s3://bucket/",
+            "AmazonS3",
+        ),
+        # A region is the one client_kwarg we know how to pass on
+        (
+            UPath("s3://bucket/a.parquet", key="AK", secret="SK", client_kwargs={"region_name": "us-1"}),
+            "s3://bucket/",
+            "AmazonS3",
+        ),
+    ],
+)
+def test_datafusion_object_store(data, expected_base, expected_store):
+    """We build a store only from what the path itself carries, never the environment."""
+    base_url, store = _datafusion_object_store(UPath(data))
+    assert base_url == expected_base
+    assert type(store).__name__ == expected_store
+
+
+@pytest.mark.parametrize(
+    "data,match",
+    [
+        # Plain HTTP: the object store needs allow_http, which Http() does not take
+        ("http://data.example.com/a.parquet", "cannot build an object store"),
+        # Protocols we have not wired up
+        (UPath("gs://bucket/a.parquet"), "cannot build an object store"),
+        (UPath("az://container/a.parquet"), "cannot build an object store"),
+        # No credentials at all, and datafusion cannot request anonymously
+        (UPath("s3://bucket/a.parquet"), "needs both 'key' and 'secret'"),
+        (UPath("s3://bucket/a.parquet", anon=True), "needs both 'key' and 'secret'"),
+        # Half a credential pair is not enough
+        (UPath("s3://bucket/a.parquet", key="AK"), "needs both 'key' and 'secret'"),
+        # Options we would silently drop, named in the message
+        (
+            UPath("https://data.example.com/a.parquet", headers={"key": "value"}),
+            r"HTTPS storage options on to its object store: \['headers'\]",
+        ),
+        (
+            UPath("s3://bucket/a.parquet", key="AK", secret="SK", use_ssl=False),
+            r"S3 storage options on to its object store: \['use_ssl'\]",
+        ),
+        (
+            UPath("s3://bucket/a.parquet", key="AK", secret="SK", client_kwargs={"verify": False}),
+            r"S3 storage options on to its object store: \['verify'\]",
+        ),
+        # A session token: AmazonS3 cannot take one on our oldest datafusion
+        (
+            UPath("s3://bucket/a.parquet", key="AK", secret="SK", token="T"),
+            r"S3 storage options on to its object store: \['token'\]",
+        ),
+    ],
+)
+def test_datafusion_object_store_unsupported(data, match):
+    """A path we cannot build a store for raises, and says which part we choked on."""
+    with pytest.raises(ValueError, match=match):
+        _datafusion_object_store(UPath(data))
+
+
+def test_datafusion_object_store_is_reused():
+    """Building a store stands up an HTTPS client, so equivalent paths share one."""
+    https = UPath("https://data.example.com/a.parquet")
+    other = UPath("https://data.example.com/b/c.parquet")
+    # Same host, so the same base URL and the same store object
+    assert _datafusion_object_store(https)[1] is _datafusion_object_store(other)[1]
+    # A different host gets its own
+    assert (
+        _datafusion_object_store(https)[1]
+        is not _datafusion_object_store(UPath("https://other.example.com/a.parquet"))[1]
+    )
+
+    s3 = UPath("s3://bucket/a.parquet", key="AK", secret="SK")
+    assert (
+        _datafusion_object_store(s3)[1]
+        is _datafusion_object_store(UPath("s3://bucket/b.parquet", key="AK", secret="SK"))[1]
+    )
+    # Different credentials must never share a client
+    assert (
+        _datafusion_object_store(s3)[1]
+        is not _datafusion_object_store(UPath("s3://bucket/a.parquet", key="AK", secret="OTHER"))[1]
+    )
+
+
+def test_datafusion_object_store_does_not_mutate_storage_options():
+    """Reading the options out of a UPath leaves the UPath alone."""
+    path = UPath("s3://bucket/a.parquet", key="AK", secret="SK", client_kwargs={"region_name": "us-1"})
+    _datafusion_object_store(path)
+    assert dict(path.storage_options) == {
+        "key": "AK",
+        "secret": "SK",
+        "client_kwargs": {"region_name": "us-1"},
+    }
 
 
 def test_datafusion_read_table_local_filesystem():

--- a/tests/nested_pandas/nestedframe/test_io.py
+++ b/tests/nested_pandas/nestedframe/test_io.py
@@ -19,9 +19,13 @@ from nested_pandas.datasets import generate_data
 from nested_pandas.nestedframe.io import (
     FSSPEC_BLOCK_SIZE,
     _columns_to_load,
+    _datafusion_filters_to_expr,
+    _datafusion_read_table,
     _get_storage_options,
+    _pyarrow_read_table,
     _transform_read_parquet_data_arg,
     from_pyarrow,
+    get_the_best_engine,
 )
 
 
@@ -697,3 +701,358 @@ def test__columns_to_load():
     # tuple in nested list that can't be unpacked into (col, op, val) → ValueError
     with pytest.raises(ValueError, match="filters format must be"):
         _columns_to_load(cols, [[("z", "<", 0.5, "extra")]])
+
+
+# ------------------------------------------------------------------------------
+# "datafusion" engine
+# ------------------------------------------------------------------------------
+
+# (columns, filters) pairs the "datafusion" and "pyarrow" engines must agree on
+DATAFUSION_READ_CASES = [
+    (None, None),
+    (["a"], None),
+    (["a", "flux"], None),
+    (["nested.flux"], None),
+    (["nested.flux", "nested.t"], None),
+    # The same leaf name in two nested columns, pyarrow returns two "band" columns
+    (["nested.band", "lincc.band"], None),
+    # The order of the requested columns must be preserved
+    (["nested.t", "a", "lincc.frameworks"], None),
+    (None, [("a", ">", 0.5)]),
+    (["a"], [("a", ">", 0.5)]),
+    # The filter column is not among the loaded ones
+    (["nested.flux"], [("flux", "<", 50.0)]),
+    # A filter on a column loaded as a nested sub-column
+    (["a", "nested.t"], [("a", "<", 0.5)]),
+    # Conjunction
+    (["a"], [("a", ">", 0.1), ("a", "<", 0.9)]),
+    # Disjunction of conjunctions
+    (["a"], [[("a", "<", 0.1)], [("a", ">", 0.5), ("flux", "<", 50.0)]]),
+    # Every comparison operator
+    (["a"], [("a", "=", 0.417022004702574)]),
+    (["a"], [("a", "==", 0.417022004702574)]),
+    (["a"], [("a", "!=", 0.417022004702574)]),
+    (["a"], [("a", ">=", 0.5)]),
+    (["a"], [("a", "<=", 0.5)]),
+    # in / not in
+    (["a", "flux"], [("a", "in", [0.417022004702574, 0.7203244934421581])]),
+    (["a", "flux"], [("a", "not in", [0.417022004702574])]),
+    # A filter matching nothing
+    (["a"], [("a", ">", 1e9)]),
+]
+
+
+@pytest.mark.parametrize("columns,filters", DATAFUSION_READ_CASES)
+def test_read_parquet_datafusion_matches_pyarrow(columns, filters):
+    """The "datafusion" engine returns exactly what the "pyarrow" engine returns."""
+    path = "tests/test_data/nested.parquet"
+
+    pyarrow_nf = read_parquet(path, columns=columns, filters=filters, engine="pyarrow")
+    datafusion_nf = read_parquet(path, columns=columns, filters=filters, engine="datafusion")
+
+    assert_frame_equal(datafusion_nf, pyarrow_nf)
+
+
+def test_read_parquet_datafusion_pandas_metadata():
+    """The pandas metadata survives the datafusion read, so the index is restored."""
+    # pandas writes the "pandas" schema metadata, nested-pandas' to_parquet does not
+    df = pd.DataFrame({"a": [1, 2, 3]}, index=pd.Index([10, 11, 12], name="object_id"))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "meta.parquet")
+        df.to_parquet(path)
+
+        assert b"pandas" in _datafusion_read_table(path).schema.metadata
+
+        for use_pandas_metadata in [True, False]:
+            assert_frame_equal(
+                read_parquet(path, engine="datafusion", use_pandas_metadata=use_pandas_metadata),
+                read_parquet(path, engine="pyarrow", use_pandas_metadata=use_pandas_metadata),
+            )
+
+        # The index is restored from the metadata, rather than left as a column
+        assert read_parquet(path, engine="datafusion").index.name == "object_id"
+        assert read_parquet(path, engine="datafusion", use_pandas_metadata=False).index.name is None
+
+
+def test_read_parquet_datafusion_directory():
+    """The "datafusion" engine reads a directory of parquet files."""
+    nf = generate_data(10, 5, seed=1)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i in range(2):
+            nf.iloc[5 * i : 5 * (i + 1)].to_parquet(os.path.join(tmpdir, f"part{i}.parquet"))
+
+        pyarrow_nf = read_parquet(tmpdir, columns=["a", "nested.t"], engine="pyarrow")
+        datafusion_nf = read_parquet(tmpdir, columns=["a", "nested.t"], engine="datafusion")
+
+    # datafusion makes no promise about the order it reads the files in
+    assert_frame_equal(
+        datafusion_nf.sort_values("a", ignore_index=True),
+        pyarrow_nf.sort_values("a", ignore_index=True),
+    )
+
+
+def test_read_parquet_datafusion_row_order():
+    """Rows come back in file order, as they do from pyarrow.
+
+    In parallel datafusion splits the row groups of even a single file across
+    partitions, and the output order is then not even reproducible run to run.
+    """
+    # The scan is only split when each partition would be worth it, so the file has
+    # to be bigger than roughly `target_partitions` (the CPU count) megabytes. On a
+    # machine with many more cores than this file has megabytes the split does not
+    # happen and this test passes whatever the settings are; the directory test
+    # below has no such threshold.
+    n_rows = 2_000_000
+    expected = np.arange(n_rows)
+    table = pa.table({"i": pa.array(expected)})
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Several row groups, so there is something for datafusion to split
+        path = os.path.join(tmpdir, "ordered.parquet")
+        pq.write_table(table, path, row_group_size=50_000, compression="none")
+
+        for _ in range(3):
+            actual = _datafusion_read_table(path)
+            np.testing.assert_array_equal(actual.column("i").to_numpy(), expected)
+
+        # A filtered read keeps the order of the rows it selects, and those come
+        # from row groups far enough apart to land in different partitions
+        selected = [7, n_rows // 2, n_rows - 1]
+        actual = _datafusion_read_table(path, filters=[("i", "in", selected)])
+        assert actual.column("i").to_pylist() == selected
+
+
+def test_read_parquet_datafusion_directory_row_order():
+    """A directory is read in the same order pyarrow reads it, file by file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i in range(4):
+            pq.write_table(pa.table({"i": pa.array([10 * i, 10 * i + 1])}), f"{tmpdir}/part{i}.parquet")
+
+        expected = _pyarrow_read_table(tmpdir).column("i").to_pylist()
+        for _ in range(3):
+            assert _datafusion_read_table(tmpdir).column("i").to_pylist() == expected
+
+
+def test_read_parquet_datafusion_quoted_column_names():
+    """Names datafusion would otherwise lower-case or split on the dot."""
+    table = pa.table(
+        {
+            "CamelCase": pa.array([1, 2]),
+            "nested": pa.array([{"Sub": [1.0]}, {"Sub": [2.0]}]),
+        }
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "names.parquet")
+        pq.write_table(table, path)
+
+        nf = read_parquet(path, columns=["CamelCase", "nested.Sub"], engine="datafusion")
+
+    assert nf.columns.tolist() == ["CamelCase", "nested"]
+    assert nf.nested.nest.columns == ["Sub"]
+
+
+def test_read_parquet_datafusion_list_struct_error():
+    """Partially loading a list-of-structs column gives the pyarrow engine's error."""
+    path = "tests/list_struct_data/list_struct.parquet"
+    with pytest.raises(ValueError, match="not a struct"):
+        read_parquet(path, columns=["lightcurve.hmjd"], engine="datafusion")
+
+
+def test_read_parquet_datafusion_missing_column_error():
+    """A plain naming mistake still raises."""
+    with pytest.raises(Exception, match="not_a_column"):
+        read_parquet("tests/test_data/nested.parquet", columns=["not_a_column"], engine="datafusion")
+
+
+class _PointExtensionType(pa.ExtensionType):
+    """A custom extension type, to check datafusion doesn't drop the unknown ones."""
+
+    def __init__(self):
+        super().__init__(pa.list_(pa.float64(), 2), "nested_pandas.test.point")
+
+    def __arrow_ext_serialize__(self):
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        return cls()
+
+
+@pytest.fixture(name="point_extension_type")
+def fixture_point_extension_type():
+    """Register the custom extension type for the duration of a single test."""
+    point_type = _PointExtensionType()
+    pa.register_extension_type(point_type)
+    yield point_type
+    pa.unregister_extension_type(point_type.extension_name)
+
+
+@pytest.mark.parametrize("pass_schema", [True, False])
+@pytest.mark.parametrize("store_schema", [True, False])
+def test_datafusion_read_table_extension_types(point_extension_type, store_schema, pass_schema):
+    """Extension types come back from a datafusion read, not their storage types.
+
+    datafusion has no notion of an extension type, it carries the storage type and
+    the "ARROW:extension:*" field metadata, and pyarrow rebuilds the type from its
+    own registry. The metadata comes either from the file's own arrow schema, or
+    from the `schema` argument. With neither, only the storage type is left.
+    """
+    tensor_type = pa.fixed_shape_tensor(pa.float64(), [2, 2])
+    table = pa.table(
+        {
+            "tensor": pa.ExtensionArray.from_storage(
+                tensor_type,
+                pa.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], pa.list_(pa.float64(), 4)),
+            ),
+            "point": pa.ExtensionArray.from_storage(
+                point_extension_type,
+                pa.array([[1.0, 2.0], [3.0, 4.0]], pa.list_(pa.float64(), 2)),
+            ),
+            "a": pa.array([1, 2]),
+        }
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "extension.parquet")
+        writer = pq.ParquetWriter(path, table.schema, store_schema=store_schema)
+        writer.write_table(table)
+        writer.close()
+
+        schema = table.schema if pass_schema else None
+        actual = _datafusion_read_table(path, schema=schema)
+        projected = _datafusion_read_table(path, columns=["tensor", "point"], schema=schema)
+
+    if store_schema or pass_schema:
+        assert actual.schema.types == [tensor_type, point_extension_type, pa.int64()]
+        # The types survive the projection too
+        assert projected.schema.types == [tensor_type, point_extension_type]
+
+        # The tensor is readable as a tensor: to_pylist() would only give the flat
+        # storage lists, the [2, 2] shape is what the extension type is for
+        for tensor_column in [actual.column("tensor"), projected.column("tensor")]:
+            ndarray = tensor_column.combine_chunks().to_numpy_ndarray()
+            assert ndarray.shape == (2, 2, 2)
+            np.testing.assert_array_equal(ndarray, [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]])
+
+        assert projected.column("point").to_pylist() == [[1.0, 2.0], [3.0, 4.0]]
+    else:
+        # There is nothing to rebuild them from, only the physical parquet types are
+        # left. They are not even the storage types: parquet does not record the
+        # fixed length of a list, so both come back as a variable-length list.
+        assert not any(isinstance(type_, pa.ExtensionType) for type_ in actual.schema.types)
+        assert actual.schema.types == [
+            pa.list_(pa.float64()),
+            pa.list_(pa.float64()),
+            pa.int64(),
+        ]
+
+
+def test_datafusion_read_table_unregistered_extension_type():
+    """An unregistered extension type keeps its metadata, exactly as with pyarrow."""
+    point_type = _PointExtensionType()
+    pa.register_extension_type(point_type)
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "point.parquet")
+    try:
+        table = pa.table(
+            {
+                "point": pa.ExtensionArray.from_storage(
+                    point_type, pa.array([[1.0, 2.0]], pa.list_(pa.float64(), 2))
+                )
+            }
+        )
+        pq.write_table(table, path)
+    finally:
+        pa.unregister_extension_type(point_type.extension_name)
+
+    # The type is no longer registered, so pyarrow cannot rebuild it for either engine
+    for read_table in [_pyarrow_read_table, _datafusion_read_table]:
+        actual = read_table(path)
+        assert actual.schema.field("point").type == point_type.storage_type
+        assert actual.schema.field("point").metadata[b"ARROW:extension:name"] == b"nested_pandas.test.point"
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        # Nothing to prune, datafusion would only add its query planning overhead
+        ({}, "pyarrow"),
+        ({"columns": ["a", "flux"]}, "pyarrow"),
+        # A nested sub-column, which pyarrow cannot push down to the leaf
+        ({"columns": ["nested.flux"]}, "datafusion"),
+        ({"columns": ["a", "nested.flux"]}, "datafusion"),
+        # A filter, which datafusion pushes into the parquet reader
+        ({"filters": [("a", ">", 0.5)]}, "datafusion"),
+        ({"columns": ["a"], "filters": [("a", ">", 0.5)]}, "datafusion"),
+        # Reads datafusion cannot serve at all, despite their shape
+        ({"columns": ["nested.flux"], "filters": pc.field("a") > 0.5}, "pyarrow"),
+        ({"columns": ["nested.flux"], "read_dictionary": ["a"]}, "pyarrow"),
+        ({"columns": ["nested.flux"], "use_threads": False}, "pyarrow"),
+        # use_threads=True is what datafusion does anyway
+        ({"columns": ["nested.flux"], "use_threads": True}, "datafusion"),
+    ],
+)
+def test_get_the_best_engine(kwargs, expected):
+    """The engine is picked by what datafusion can do, and by what it is better at."""
+    assert get_the_best_engine("tests/test_data/nested.parquet", **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Remote paths, both as a plain string and as a UPath
+        "https://example.com/nested.parquet",
+        "s3://bucket/nested.parquet",
+        UPath("https://example.com/nested.parquet"),
+        # A list of paths and a file-like object
+        ["tests/test_data/nested.parquet", "tests/test_data/nested.parquet"],
+        io.BytesIO(b""),
+    ],
+)
+def test_get_the_best_engine_unsupported_data(data):
+    """Sources datafusion cannot read fall back to pyarrow, even for a read it wins at."""
+    assert get_the_best_engine(data, columns=["nested.flux"], filters=[("a", ">", 0.5)]) == "pyarrow"
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"data": "https://example.com/nested.parquet"}, "local paths only"),
+        ({"data": UPath("s3://bucket/nested.parquet")}, "local paths only"),
+        ({"data": ["a.parquet", "b.parquet"]}, "single path only"),
+        ({"data": io.BytesIO(b"")}, "single path only"),
+        ({"filesystem": fsspec.implementations.http.HTTPFileSystem()}, "not supported"),
+        ({"filters": pc.field("a") > 0.5}, "PyArrow Expression"),
+        ({"read_dictionary": ["a"]}, "not supported"),
+        ({"use_threads": False}, "use_threads=False"),
+    ],
+)
+def test_datafusion_read_table_unsupported(kwargs, match):
+    """What datafusion cannot serve raises, and names the engine to use instead."""
+    kwargs = {"data": "tests/test_data/nested.parquet", **kwargs}
+    with pytest.raises(ValueError, match=match):
+        _datafusion_read_table(**kwargs)
+
+
+def test_datafusion_read_table_local_filesystem():
+    """A local pyarrow filesystem is accepted, it is what datafusion would use anyway."""
+    path = UPath("tests/test_data/nested.parquet")
+    actual = _datafusion_read_table(path.path, filesystem=pyarrow.fs.LocalFileSystem())
+    assert actual.column_names == ["a", "flux", "nested", "lincc"]
+
+
+@pytest.mark.parametrize(
+    "filters,match",
+    [
+        ("a > 0.5", "filters must be"),
+        (42, "filters must be"),
+        ([], "filters format must be"),
+        ([[]], "filters format must be"),
+        ([("a", ">", 0.5), "not_a_tuple"], "filters format must be"),
+        ([[("a", ">", 0.5, "extra")]], "filters format must be"),
+        ([("a", "~=", 0.5)], "Unsupported filter operator"),
+    ],
+)
+def test_datafusion_filters_to_expr_errors(filters, match):
+    """Malformed filters are rejected with the messages the pyarrow path uses."""
+    with pytest.raises(ValueError, match=match):
+        _datafusion_filters_to_expr(filters)


### PR DESCRIPTION
Adds initial and optional support for `datafusion` as a Parquet reader engine. In certain cases, `datafusion` may be 10–50 times faster than `pyarrow`, for instance, when selecting a few rows only from a file with page statistics or when selecting up to ~20% of nested subcolumns.

Further improvements will be required to automatically switch engine for better performance.