### PR TITLE
Add Tensor Extension Array

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.mypy]
 python_version = "3.10"
+# Resolve module names from src/ and tests/ so the two conftest.py files do not collide
+mypy_path = "src"
+explicit_package_bases = true
 
 [tool.setuptools_scm]
 write_to = "src/nested_pandas/_version.py"

--- a/src/nested_pandas/series/ext_array.py
+++ b/src/nested_pandas/series/ext_array.py
@@ -70,6 +70,7 @@ from nested_pandas.series.utils import (
     normalize_list_array,
     normalize_struct_list_type,
     rechunk,
+    replace_with_mask,
     safe_cast,
     scalars_to_pa_array,
     struct_field_names,
@@ -179,22 +180,6 @@ def to_pyarrow_dtype(
     if isinstance(dtype, pa.DataType):
         return dtype
     return None
-
-
-def replace_with_mask(array: pa.ChunkedArray, mask: pa.BooleanArray, value: pa.Array) -> pa.ChunkedArray:
-    """Replace the elements of the array with the value where the mask is True"""
-    # TODO: performance optimization
-    # https://github.com/lincc-frameworks/nested-pandas/issues/52
-
-    # If mask is [False, True, False, True], mask_cumsum will be [0, 1, 1, 2]
-    # So we put value items to the right positions in broadcast_value, while duplicate some other items for
-    # the positions where mask is False.
-    mask_cumsum = pa.compute.cumulative_sum(mask.cast(pa.int64()))
-    value_index = pa.compute.subtract(mask_cumsum, 1)
-    value_index = pa.compute.if_else(pa.compute.less(value_index, 0), 0, value_index)
-
-    broadcast_value = value.take(value_index)
-    return pa.compute.if_else(mask, broadcast_value, array)
 
 
 def convert_df_to_pa_scalar(df: pd.DataFrame, *, pa_type: pa.StructType | None) -> pa.Scalar:

--- a/src/nested_pandas/series/utils.py
+++ b/src/nested_pandas/series/utils.py
@@ -839,3 +839,39 @@ def scalars_to_pa_array(scalars: Sequence[pa.Scalar], pa_type: pa.DataType) -> p
         return list_cls.from_arrays(offsets_array, values, mask=mask)
 
     return pa.array(scalars, type=pa_type)
+
+
+def replace_with_mask(array: pa.ChunkedArray, mask: pa.BooleanArray, value: pa.Array) -> pa.ChunkedArray:
+    """Replace the elements of the array with the value where the mask is True
+
+    A stand-in for ``pa.compute.replace_with_mask``, which has no kernels for
+    nested types such as struct and fixed_size_list arrays
+    (https://github.com/apache/arrow/issues/29558). Built from ``take`` and
+    ``if_else``, which do support them.
+
+    Parameters
+    ----------
+    array : pa.ChunkedArray
+        The array to replace elements in.
+    mask : pa.BooleanArray
+        Where True, take the element from ``value`` instead of ``array``.
+    value : pa.Array
+        Replacement elements, one per True in ``mask``, in order.
+
+    Returns
+    -------
+    pa.ChunkedArray
+        The array with the masked elements replaced.
+    """
+    # TODO: performance optimization
+    # https://github.com/lincc-frameworks/nested-pandas/issues/52
+
+    # If mask is [False, True, False, True], mask_cumsum will be [0, 1, 1, 2]
+    # So we put value items to the right positions in broadcast_value, while duplicate some other items for
+    # the positions where mask is False.
+    mask_cumsum = pa.compute.cumulative_sum(mask.cast(pa.int64()))
+    value_index = pa.compute.subtract(mask_cumsum, 1)
+    value_index = pa.compute.if_else(pa.compute.less(value_index, 0), 0, value_index)
+
+    broadcast_value = value.take(value_index)
+    return pa.compute.if_else(mask, broadcast_value, array)

--- a/src/nested_pandas/tensors/__init__.py
+++ b/src/nested_pandas/tensors/__init__.py
@@ -1,3 +1,4 @@
 from .dtype import TensorDtype
+from .ext_array import TensorExtensionArray
 
-__all__ = ["TensorDtype"]
+__all__ = ["TensorDtype", "TensorExtensionArray"]

--- a/src/nested_pandas/tensors/dtype.py
+++ b/src/nested_pandas/tensors/dtype.py
@@ -89,11 +89,9 @@ class TensorDtype(ExtensionDtype):
     @classmethod
     def construct_array_type(cls) -> Type[ExtensionArray]:
         """Corresponding array type, always TensorExtensionArray"""
-        # TODO: enable once TensorExtensionArray is merged
-        # from nested_pandas.tensors.ext_array import TensorExtensionArray
-        #
-        # return TensorExtensionArray
-        raise NotImplementedError("TensorExtensionArray is not implemented yet")
+        from nested_pandas.tensors.ext_array import TensorExtensionArray
+
+        return TensorExtensionArray
 
     @classmethod
     def construct_from_string(cls, string: str) -> Self:  # type: ignore[name-defined] # noqa: F821
@@ -171,11 +169,9 @@ class TensorDtype(ExtensionDtype):
         TensorExtensionArray
             The constructed TensorExtensionArray.
         """
-        # TODO: enable once TensorExtensionArray is merged
-        # from nested_pandas.tensors.ext_array import TensorExtensionArray
-        #
-        # return TensorExtensionArray(array, dtype=self)
-        raise NotImplementedError("TensorExtensionArray is not implemented yet")
+        from nested_pandas.tensors.ext_array import TensorExtensionArray
+
+        return TensorExtensionArray(array, dtype=self)
 
     # Additional methods and attributes #
 

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -362,6 +362,50 @@ class TensorExtensionArray(ExtensionArray):
         for scalar in self._pa_array:
             yield self._scalar_to_numpy(scalar)
 
+    def __eq__(self, other):  # type: ignore[override]
+        """Elementwise equality with another array of tensors, or with a single tensor.
+
+        Two tensors are equal when they have the same dtype and all their values
+        are equal, with numpy's semantics for the values (so NaN != NaN). The
+        result is NA where either side is missing. Comparing to anything that
+        cannot be interpreted as tensors of this dtype, including an array of a
+        different tensor dtype, gives False everywhere.
+
+        Returns
+        -------
+        pd.arrays.BooleanArray
+        """
+        # Let pandas unbox these and dispatch back to us with the underlying array
+        if isinstance(other, pd.Series | pd.Index | pd.DataFrame):
+            return NotImplemented
+
+        self_mask = self.isna()
+        other_array = self._coerce_comparison_operand(other)
+        if other_array is None:
+            return pd.arrays.BooleanArray(np.zeros(len(self), dtype=bool), self_mask)
+        if len(other_array) not in (1, len(self)):
+            raise ValueError("Lengths must match to compare")
+
+        # Compare the flat values row by row; a length-1 operand broadcasts
+        left = self._values_block().reshape(len(self), self.dtype.size)
+        right = other_array._values_block().reshape(len(other_array), self.dtype.size)
+        equal = np.all(left == right, axis=1)
+        mask = self_mask | other_array.isna()
+        return pd.arrays.BooleanArray(equal, mask)
+
+    def _coerce_comparison_operand(self, other: Any) -> Self | None:  # type: ignore[name-defined] # noqa: F821
+        """Convert the other side of a comparison to an array of this dtype, or None if impossible."""
+        if _is_na(other):
+            return type(self)._from_sequence([None], dtype=self.dtype)
+        if isinstance(other, TensorExtensionArray):
+            return other if other.dtype == self.dtype else None
+        if isinstance(other, np.ndarray) and other.shape == self.dtype.shape:
+            other = [other]
+        try:
+            return type(self)._from_sequence(other, dtype=self.dtype)
+        except (TypeError, ValueError, pa.ArrowInvalid, pa.ArrowTypeError):
+            return None
+
     def to_numpy(
         self,
         dtype: DTypeLike | None = None,
@@ -718,6 +762,22 @@ class TensorExtensionArray(ExtensionArray):
         np.ndarray
             Array of shape ``(len(self), *self.dtype.shape)``.
         """
+        stack = self._values_block()
+        if not self._hasna:
+            return stack
+
+        # The block holds arbitrary values for null tensors, so fill them here
+        result_dtype = np.result_type(stack.dtype, np.min_scalar_type(na_value))
+        result = np.array(stack, dtype=result_dtype)
+        result[self.isna()] = na_value
+        return result
+
+    def _values_block(self) -> np.ndarray:
+        """Read-only numpy view of shape ``(n, *shape)`` over the arrow buffers.
+
+        Zero-copy for a single chunk. Null tensors are present in the block
+        but hold arbitrary values, so callers must consult :meth:`isna`.
+        """
         if len(self) == 0:
             return np.empty((0, *self.dtype.shape), dtype=_numpy_value_dtype(self.dtype))
 
@@ -726,15 +786,7 @@ class TensorExtensionArray(ExtensionArray):
             combined = cast(pa.FixedShapeTensorArray, self._pa_array.chunk(0))
         else:
             combined = cast(pa.FixedShapeTensorArray, self._pa_array.combine_chunks())
-        stack = combined.to_numpy_ndarray()
-        if combined.null_count == 0:
-            return stack
-
-        # to_numpy_ndarray() silently returns garbage for null tensors, so fill them here
-        result_dtype = np.result_type(stack.dtype, np.min_scalar_type(na_value))
-        result = np.array(stack, dtype=result_dtype)
-        result[self.isna()] = na_value
-        return result
+        return combined.to_numpy_ndarray()
 
     @classmethod
     def from_arrow_ext_array(cls, array: ArrowExtensionArray, *, dtype: TensorDtype | None = None) -> Self:  # type: ignore[name-defined] # noqa: F821

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -1,0 +1,741 @@
+# This code is massively adopted from pandas' ArrowExtensionArray. Pandas license is required for this code:
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2008-2011, AQR Capital Management, LLC, Lambda Foundry, Inc. and PyData Development Team
+# All rights reserved.
+#
+# Copyright (c) 2011-2024, Open source contributors.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Pandas extension array for fixed-shape tensor columns."""
+
+from __future__ import annotations  # Self in Python 3.10
+
+from collections.abc import Callable, Iterator, Sequence
+from typing import Any, cast
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+from numpy.typing import DTypeLike
+from pandas.api.extensions import no_default
+from pandas.api.types import pandas_dtype
+from pandas.core.arrays import ArrowExtensionArray, ExtensionArray  # type: ignore[attr-defined]
+from pandas.core.indexers import (  # type: ignore[attr-defined]
+    check_array_indexer,
+    unpack_tuple_and_ellipses,
+    validate_indices,
+)
+
+from nested_pandas.series.ext_array import replace_with_mask
+from nested_pandas.tensors.dtype import TensorDtype
+
+__all__ = ["TensorExtensionArray"]
+
+
+TENSOR_FORMATTING_MAX_ELEMENTS = 12
+"""Tensors with more elements than this show a shape/dtype descriptor instead of their values in reprs"""
+
+
+def _tensor_descriptor(value: np.ndarray) -> str:
+    """Short description of a tensor for reprs, e.g. '[64×64] float32'."""
+    return f"[{'×'.join(str(size) for size in value.shape)}] {value.dtype}"
+
+
+def _format_tensor(value: Any) -> str:
+    """Format a single tensor (or missing value) for Series and DataFrame text reprs.
+
+    Small tensors show all their values, larger ones only a shape and dtype
+    descriptor. Values are formatted via ``tolist()`` rather than
+    ``np.array2string`` so that every row of a column uses the same style,
+    with no alignment padding or per-tensor switching to scientific notation.
+    """
+    if _is_na(value):
+        return str(pd.NA)
+    if value.size > TENSOR_FORMATTING_MAX_ELEMENTS:
+        return _tensor_descriptor(value)
+    return str(value.tolist())
+
+
+def _is_na(value: Any) -> bool:
+    """Whether a scalar value represents a missing tensor."""
+    return value is None or value is pd.NA or (isinstance(value, float) and np.isnan(value))
+
+
+def _numpy_value_dtype(dtype: TensorDtype) -> np.dtype:
+    """Numpy dtype of the tensor elements."""
+    return np.dtype(dtype.value_type.to_pandas_dtype())
+
+
+def _normalize_dtype(dtype: Any) -> TensorDtype | None:
+    """Convert the supported dtype spellings to TensorDtype, passing None through."""
+    if dtype is None or isinstance(dtype, TensorDtype):
+        return dtype
+    if isinstance(dtype, pa.FixedShapeTensorType | pd.ArrowDtype):
+        return TensorDtype(dtype)
+    if isinstance(dtype, str):
+        pd_dtype = pandas_dtype(dtype)
+        if isinstance(pd_dtype, TensorDtype):
+            return pd_dtype
+    raise TypeError(
+        "Expected TensorDtype, pa.FixedShapeTensorType, pd.ArrowDtype of a tensor type or a tensor dtype "
+        f"string, got {dtype!r}"
+    )
+
+
+def _storage_of(array: pa.ChunkedArray) -> pa.ChunkedArray:
+    """Fixed-size-list storage of a tensor-typed chunked array."""
+    pa_type = cast(pa.FixedShapeTensorType, array.type)
+    return pa.chunked_array([chunk.storage for chunk in array.iterchunks()], type=pa_type.storage_type)
+
+
+def _tensor_to_flat(value: Any, dtype: TensorDtype) -> np.ndarray:
+    """Validate a single tensor against the dtype and return its values flattened in C order."""
+    if isinstance(value, pa.FixedShapeTensorScalar):
+        array = value.to_numpy()
+    elif isinstance(value, pa.Scalar):
+        array = np.asarray(value.as_py())
+        # A fixed_size_list scalar comes back flat
+        if array.shape != dtype.shape and array.size == dtype.size:
+            array = array.reshape(dtype.shape)
+    else:
+        array = np.asarray(value)
+    if array.shape != dtype.shape:
+        raise ValueError(f"Expected a tensor of shape {dtype.shape}, got shape {array.shape}")
+    return np.ascontiguousarray(array).reshape(-1)
+
+
+class TensorExtensionArray(ExtensionArray):
+    """Pandas extension array for fixed-shape tensors
+
+    Every element is a numpy array of the same shape and element type, stored
+    as a pyarrow ``fixed_shape_tensor`` extension array. Scalar access and
+    :meth:`to_stack` return read-only numpy views over the arrow buffers
+    whenever possible, so no data is copied.
+
+    Parameters
+    ----------
+    values : pyarrow.Array or pyarrow.ChunkedArray
+        The array to be wrapped. Either a ``fixed_shape_tensor`` extension
+        array, or its ``fixed_size_list`` storage array, in which case
+        ``dtype`` is required.
+    dtype : TensorDtype, optional
+        The dtype of the array. Required when ``values`` is a storage array,
+        otherwise inferred from ``values.type``. If given and different from
+        the type of ``values``, the storage is cast to the dtype.
+
+    Raises
+    ------
+    TypeError
+        If ``values`` is not a pyarrow array.
+    ValueError
+        If ``values`` is neither a tensor nor a fixed_size_list array, or if it
+        is a fixed_size_list array and ``dtype`` is not given.
+    """
+
+    # Constructor and initialized attributes #
+
+    _pa_array: pa.ChunkedArray
+    _dtype: TensorDtype
+
+    def __init__(self, values: pa.Array | pa.ChunkedArray, *, dtype: TensorDtype | None = None) -> None:
+        if isinstance(values, pa.Array):
+            values = pa.chunked_array([values])
+        if not isinstance(values, pa.ChunkedArray):
+            raise TypeError(f"values must be a pyarrow Array or ChunkedArray, got {type(values)}")
+        dtype = _normalize_dtype(dtype)
+
+        if isinstance(values.type, pa.FixedShapeTensorType):
+            if dtype is None:
+                dtype = TensorDtype(values.type)
+            elif dtype.pyarrow_dtype != values.type:
+                values = self._wrap_storage(_storage_of(values), dtype)
+        elif pa.types.is_fixed_size_list(values.type):
+            if dtype is None:
+                raise ValueError("dtype is required when constructing from a fixed_size_list storage array")
+            values = self._wrap_storage(values, dtype)
+        else:
+            raise ValueError(
+                f"values must be a fixed_shape_tensor or fixed_size_list array, got type {values.type}"
+            )
+
+        self._pa_array = values
+        self._dtype = dtype
+
+    @staticmethod
+    def _wrap_storage(storage: pa.ChunkedArray, dtype: TensorDtype) -> pa.ChunkedArray:
+        """Cast fixed_size_list storage to the dtype's storage type and wrap it as the tensor type."""
+        if storage.type != dtype.storage_type:
+            if storage.type.list_size != dtype.size:
+                raise ValueError(
+                    f"Cannot convert tensors of {storage.type.list_size} elements to {dtype}, "
+                    f"which has {dtype.size} elements"
+                )
+            storage = storage.cast(dtype.storage_type)
+        pa_type = dtype.pyarrow_dtype
+        chunks = [pa.ExtensionArray.from_storage(pa_type, chunk) for chunk in storage.iterchunks()]
+        return pa.chunked_array(chunks, type=pa_type)
+
+    # End of Constructor and initialized attributes #
+
+    # ExtensionArray overrides #
+
+    @classmethod
+    def _from_sequence(cls, scalars, *, dtype=None, copy: bool = False) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Construct a TensorExtensionArray from a sequence of scalars.
+
+        Parameters
+        ----------
+        scalars : Sequence
+            The sequence of scalars: numpy arrays (or anything convertible to
+            them) of the tensor shape, None, pd.NA, or pyarrow scalars. A
+            numpy array of shape ``(n, *shape)`` is accepted as a stack.
+        dtype : TensorDtype, pa.FixedShapeTensorType, pd.ArrowDtype or str, optional
+            dtype of the resulting array. Inferred from the first non-missing
+            element if not given.
+        copy : bool
+            Ignored, because PyArrow arrays are immutable.
+        """
+        del copy
+        dtype = _normalize_dtype(dtype)
+
+        if isinstance(scalars, cls):
+            if dtype is None or dtype == scalars.dtype:
+                return scalars
+            return scalars.astype(dtype)
+        if isinstance(scalars, pa.Array | pa.ChunkedArray):
+            return cls(scalars, dtype=dtype)
+        if isinstance(scalars, np.ndarray) and scalars.dtype != np.object_ and scalars.ndim >= 2:
+            return cls.from_stack(scalars, dtype=dtype)
+
+        scalars = list(scalars)
+        mask = np.array([_is_na(value) for value in scalars], dtype=bool)
+
+        if dtype is None:
+            first = next((value for value, na in zip(scalars, mask, strict=True) if not na), None)
+            if first is None:
+                raise ValueError("Cannot infer TensorDtype from a sequence without non-missing values")
+            if isinstance(first, pa.FixedShapeTensorScalar):
+                first = first.to_numpy()
+            first = np.asarray(first)
+            dtype = TensorDtype(pa.fixed_shape_tensor(pa.from_numpy_dtype(first.dtype), list(first.shape)))
+
+        np_value_dtype = _numpy_value_dtype(dtype)
+        flats = [
+            np.zeros(dtype.size, dtype=np_value_dtype) if na else _tensor_to_flat(value, dtype)
+            for value, na in zip(scalars, mask, strict=True)
+        ]
+        values = np.concatenate(flats) if flats else np.empty(0, dtype=np_value_dtype)
+        storage = pa.FixedSizeListArray.from_arrays(
+            pa.array(values, type=dtype.value_type),
+            dtype.size,
+            mask=pa.array(mask) if mask.any() else None,
+        )
+        return cls(storage, dtype=dtype)
+
+    def __getitem__(self, item: ScalarIndexer) -> Self | np.ndarray:  # type: ignore[name-defined, override] # noqa: F821
+        item = check_array_indexer(self, item)
+
+        if isinstance(item, np.ndarray):
+            if len(item) == 0:
+                return type(self)(pa.chunked_array([], type=self.dtype.pyarrow_dtype), dtype=self.dtype)
+            pa_item = pa.array(item)
+            if item.dtype.kind in "iu":
+                return type(self)(self._pa_array.take(pa_item), dtype=self.dtype)
+            if item.dtype.kind == "b":
+                return type(self)(self._pa_array.filter(pa_item), dtype=self.dtype)
+            # It should be covered by check_array_indexer above
+            raise IndexError(
+                "Only integers, slices and integer or boolean arrays are valid indices."
+            )  # pragma: no cover
+
+        if isinstance(item, tuple):
+            item = unpack_tuple_and_ellipses(item)
+
+        if item is Ellipsis:
+            item = slice(None)
+
+        scalar_or_array = self._pa_array[item]
+        if isinstance(scalar_or_array, pa.Scalar):
+            return self._scalar_to_numpy(scalar_or_array)
+        # Logically, it must be a pa.ChunkedArray if it is not a scalar
+        return type(self)(cast(pa.ChunkedArray, scalar_or_array), dtype=self.dtype)
+
+    def __setitem__(self, key, value) -> None:
+        key = check_array_indexer(self, key)
+
+        if isinstance(key, tuple):
+            key = unpack_tuple_and_ellipses(key)
+
+        if not isinstance(key, np.ndarray):
+            np_mask = np.zeros(len(self), dtype=np.bool_)
+            np_mask[key] = True
+            key = np_mask
+
+        if len(key) == 0:
+            return
+
+        argsort: np.ndarray | None = None
+        if key.dtype.kind in "iu":
+            _, argsort = np.unique(key, return_index=True)
+            np_mask = np.zeros(len(self), dtype=np.bool_)
+            np_mask[key] = True
+            pa_mask = pa.array(np_mask)
+        elif key.dtype.kind == "b":
+            pa_mask = pa.array(key)
+        # Should be covered by check_array_indexer
+        else:  # pragma: no cover
+            raise IndexError(
+                "Only integers, slices and integer or boolean arrays are valid indices."
+            )  # pragma: no cover
+
+        n_set = pc.sum(pa_mask).as_py() or 0
+
+        if self._is_scalar_value(value):
+            # Our replace_with_mask implementation doesn't work with scalars, so broadcast
+            scalar = self._scalar_storage(value)
+            value_storage: pa.Array | pa.ChunkedArray = pa.repeat(scalar, n_set)
+        else:
+            value_storage = type(self)._from_sequence(value, dtype=self.dtype).storage
+            if len(value_storage) != n_set:
+                raise ValueError(
+                    f"Cannot set {n_set} elements from a sequence of length {len(value_storage)}"
+                )
+            if argsort is not None:
+                value_storage = value_storage.take(argsort)
+
+        # pa.compute.replace_with_mask() and if_else() have no kernels for the extension type,
+        # so we work on the fixed_size_list storage and wrap it back.
+        storage = replace_with_mask(self.storage, pa_mask, value_storage)
+        self._pa_array = self._wrap_storage(storage, self.dtype)
+
+    def __len__(self) -> int:
+        return len(self._pa_array)
+
+    def __iter__(self) -> Iterator[np.ndarray | Any]:
+        for scalar in self._pa_array:
+            yield self._scalar_to_numpy(scalar)
+
+    def to_numpy(
+        self,
+        dtype: DTypeLike | None = None,
+        copy: bool = False,
+        na_value: Any = no_default,
+    ) -> np.ndarray:
+        """Convert the extension array to a numpy object array of tensors.
+
+        Use :meth:`to_stack` to get a single ``(n, *shape)`` numpy array instead.
+
+        Parameters
+        ----------
+        dtype : None
+            This parameter is left for compatibility with the base class
+            method, but it is not used. dtype of the returned array is
+            always an object.
+        copy : bool, default False
+            Whether to copy the tensors. If False, the tensors are read-only
+            views over the arrow buffers.
+        na_value : Any, optional
+            The value to use for missing values. If not provided, pd.NA
+            will be used.
+
+        Returns
+        -------
+        np.ndarray
+            The numpy array of np.ndarray objects.
+        """
+        del dtype
+        if na_value is no_default:
+            na_value = pd.NA
+
+        # Hack with np.empty is the only way to force numpy to create a 1-d array of objects
+        result = np.empty(shape=len(self), dtype=object)
+
+        for i, scalar in enumerate(self._pa_array):
+            value = self._scalar_to_numpy(scalar, na_value=na_value)
+            if copy and isinstance(value, np.ndarray):
+                value = value.copy()
+            result[i] = value
+
+        return result
+
+    @property
+    def dtype(self) -> TensorDtype:
+        """ExtensionArray dtype"""
+        return self._dtype
+
+    @property
+    def nbytes(self) -> int:
+        """Number of bytes consumed by the data in memory."""
+        return self._pa_array.nbytes
+
+    def isna(self) -> np.ndarray:
+        """Boolean NumPy array indicating if each value is missing."""
+        # Fast paths adopted from ArrowExtensionArray
+        null_count = self._pa_array.null_count
+        if null_count == 0:
+            return np.zeros(len(self), dtype=bool)
+        if null_count == len(self):
+            return np.ones(len(self), dtype=bool)
+
+        return self._pa_array.is_null().to_numpy()
+
+    @property
+    def _hasna(self) -> bool:
+        return self._pa_array.null_count > 0
+
+    def astype(self, dtype, copy: bool = True):
+        """Cast to a NumPy array or ExtensionArray with 'dtype'.
+
+        Casting to another TensorDtype casts the storage, so the element type
+        may change, and the shape may change as long as the number of
+        elements is the same. Casting to pd.ArrowDtype gives an
+        ArrowExtensionArray of the tensor type or of any type the storage can
+        be cast to.
+
+        Parameters
+        ----------
+        dtype : dtype or str
+            Typecode or data-type to which the array is cast.
+        copy : bool, default True
+            Whether to copy the data, even if not necessary.
+
+        Returns
+        -------
+        np.ndarray or ExtensionArray
+        """
+        dtype = pandas_dtype(dtype)
+
+        if dtype == self.dtype:
+            return self.copy() if copy else self
+
+        if isinstance(dtype, TensorDtype):
+            return type(self)(self.storage, dtype=dtype)
+
+        if isinstance(dtype, pd.ArrowDtype):
+            pa_type = dtype.pyarrow_dtype
+            if pa_type == self.dtype.pyarrow_dtype:
+                return ArrowExtensionArray(self._pa_array)
+            return ArrowExtensionArray(self.storage.cast(pa_type))
+
+        return super().astype(dtype, copy=copy)
+
+    def take(
+        self,
+        indices,
+        *,
+        allow_fill: bool = False,
+        fill_value: Any = None,
+    ) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """
+        Take elements from an array.
+
+        Parameters
+        ----------
+        indices : sequence of int or one-dimensional np.ndarray of int
+            Indices to be taken.
+        allow_fill : bool, default False
+            How to handle negative values in `indices`.
+
+            * False: negative values in `indices` indicate positional indices
+              from the right (the default). This is similar to
+              :func:`numpy.take`.
+
+            * True: negative values in `indices` indicate
+              missing values. These values are set to `fill_value`. Any other
+              negative values raise a ``ValueError``.
+
+        fill_value : any, optional
+            Fill value to use for NA-indices when `allow_fill` is True.
+            This may be ``None``, in which case pd.NA is used.
+
+        Returns
+        -------
+        TensorExtensionArray
+
+        Raises
+        ------
+        IndexError
+            When the indices are out of bounds for the array.
+        ValueError
+            When `indices` contains negative values other than ``-1``
+            and `allow_fill` is True.
+        """
+        # Massively adopted from ArrowExtensionArray
+
+        indices_array = np.asanyarray(indices)
+        if indices_array.dtype.kind not in "iu":
+            # E.g. an empty list gives a float array
+            indices_array = indices_array.astype(np.int64)
+
+        if len(self) == 0 and (indices_array >= 0).any():
+            raise IndexError("cannot do a non-empty take from the empty array")
+        if indices_array.size > 0 and indices_array.max() >= len(self):
+            raise IndexError("out of bounds value in 'indices'.")
+
+        if allow_fill:
+            fill_mask = indices_array < 0
+            if not fill_mask.any():
+                # Nothing to fill
+                return type(self)(self._pa_array.take(pa.array(indices_array)), dtype=self.dtype)
+            validate_indices(indices_array, len(self))
+            pa_indices = pa.array(indices_array, mask=fill_mask)
+
+            # Null indices give null elements
+            storage = self.storage.take(pa_indices)
+            if not _is_na(fill_value):
+                fill_storage = pa.repeat(self._scalar_storage(fill_value), int(fill_mask.sum()))
+                storage = replace_with_mask(storage, pa.array(fill_mask), fill_storage)
+            return type(self)(storage, dtype=self.dtype)
+
+        if (indices_array < 0).any():
+            # Don't modify in-place
+            indices_array = np.copy(indices_array)
+            indices_array[indices_array < 0] += len(self)
+        return type(self)(self._pa_array.take(pa.array(indices_array)), dtype=self.dtype)
+
+    def copy(self) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Return a copy of the extension array.
+
+        This implementation returns a shallow copy of the extension array,
+        because the underlying PyArrow array is immutable.
+        """
+        return type(self)(self._pa_array, dtype=self.dtype)
+
+    def _formatter(self, boxed: bool = False) -> Callable[[Any], str | None]:
+        if boxed:
+            return _format_tensor
+        return repr
+
+    @classmethod
+    def _concat_same_type(cls, to_concat: Sequence[Self]) -> Self:  # type: ignore[name-defined] # noqa: F821
+        to_concat = list(to_concat)
+        dtype = to_concat[0].dtype
+        chunks = [chunk for ext_array in to_concat for chunk in ext_array._pa_array.iterchunks()]
+        return cls(pa.chunked_array(chunks, type=dtype.pyarrow_dtype), dtype=dtype)
+
+    def equals(self, other) -> bool:
+        """
+        Check equality with another TensorExtensionArray.
+
+        Parameters
+        ----------
+        other : TensorExtensionArray
+            The other TensorExtensionArray to compare with.
+
+        Returns
+        -------
+        bool
+            Whether the two arrays have the same dtype and the same values.
+        """
+        if not isinstance(other, type(self)):
+            return False
+        return self.dtype == other.dtype and self.storage.equals(other.storage)
+
+    def dropna(self) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Return a new ExtensionArray with missing tensors removed."""
+        return type(self)(pc.drop_null(self._pa_array), dtype=self.dtype)
+
+    # End of ExtensionArray overrides #
+
+    # Additional magic methods #
+
+    def __arrow_array__(self, type=None):  # noqa: A002
+        """Convert the extension array to a PyArrow array.
+
+        With no ``type`` this is the ``fixed_shape_tensor`` extension array,
+        so ``pa.Table.from_pandas`` and Parquet preserve the tensor type.
+        """
+        if type is None or type == self.dtype.pyarrow_dtype:
+            return self._pa_array
+        if isinstance(type, pa.FixedShapeTensorType):
+            return self._wrap_storage(self.storage, TensorDtype(type))
+        return self.storage.cast(type)
+
+    def __array__(self, dtype=None, copy=None):
+        """Convert the extension array to a numpy object array of tensors."""
+        return self.to_numpy(dtype=dtype, copy=bool(copy))
+
+    # End of Additional magic methods #
+
+    @staticmethod
+    def _scalar_to_numpy(scalar: pa.Scalar, na_value: Any = pd.NA) -> np.ndarray | Any:
+        """Convert a tensor scalar to a read-only numpy view, or to na_value if it is null."""
+        if not scalar.is_valid:
+            return na_value
+        return cast(pa.FixedShapeTensorScalar, scalar).to_numpy()
+
+    def _is_scalar_value(self, value: Any) -> bool:
+        """Whether a value passed to __setitem__ is a single tensor rather than a sequence of them."""
+        if _is_na(value) or isinstance(value, pa.Scalar):
+            return True
+        return isinstance(value, np.ndarray) and value.shape == self.dtype.shape
+
+    def _scalar_storage(self, value: Any) -> pa.Scalar:
+        """Convert a single tensor (or missing value) to a fixed_size_list storage scalar."""
+        return type(self)._from_sequence([value], dtype=self.dtype).storage[0]
+
+    @property
+    def pa_array(self) -> pa.ChunkedArray:
+        """Pyarrow chunked array of the ``fixed_shape_tensor`` extension type."""
+        return self._pa_array
+
+    @property
+    def storage(self) -> pa.ChunkedArray:
+        """Pyarrow chunked array of the ``fixed_size_list`` storage type."""
+        return _storage_of(self._pa_array)
+
+    @property
+    def num_chunks(self) -> int:
+        """Number of chunks in the underlying pyarrow.ChunkedArray"""
+        return self._pa_array.num_chunks
+
+    @classmethod
+    def from_sequence(
+        cls, scalars, *, dtype: TensorDtype | pa.FixedShapeTensorType | pd.ArrowDtype | str | None = None
+    ) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Construct a TensorExtensionArray from a sequence of tensors
+
+        Parameters
+        ----------
+        scalars : Sequence
+            The sequence of items: numpy arrays (or anything convertible to
+            them) of the tensor shape, None, pd.NA, or pyarrow scalars. A
+            numpy array of shape ``(n, *shape)`` is accepted as a stack, see
+            :meth:`from_stack`.
+        dtype : TensorDtype, pa.FixedShapeTensorType, pd.ArrowDtype or str, optional
+            dtype of the resulting array. Inferred from the first non-missing
+            element if not given.
+
+        Returns
+        -------
+        TensorExtensionArray
+            The constructed extension array.
+        """
+        return cls._from_sequence(scalars, dtype=dtype)
+
+    @classmethod
+    def from_stack(
+        cls,
+        stack: np.ndarray,
+        *,
+        dtype: TensorDtype | pa.FixedShapeTensorType | pd.ArrowDtype | str | None = None,
+    ) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Construct a TensorExtensionArray from a numpy array of shape ``(n, *shape)``
+
+        The construction is zero-copy for C-contiguous input; other layouts
+        are copied into C order first.
+
+        Parameters
+        ----------
+        stack : np.ndarray
+            Array whose first axis enumerates the tensors.
+        dtype : TensorDtype, pa.FixedShapeTensorType, pd.ArrowDtype or str, optional
+            dtype of the resulting array. Inferred from the numpy dtype and
+            ``stack.shape[1:]`` if not given.
+
+        Returns
+        -------
+        TensorExtensionArray
+            The constructed extension array.
+        """
+        stack = np.asarray(stack)
+        if stack.ndim < 2:
+            raise ValueError(f"stack must have shape (n, *shape), at least two dimensions, got {stack.shape}")
+
+        dtype = _normalize_dtype(dtype)
+        if dtype is None:
+            value_type = pa.from_numpy_dtype(stack.dtype)
+            dtype = TensorDtype(pa.fixed_shape_tensor(value_type, list(stack.shape[1:])))
+        elif stack.shape[1:] != dtype.shape:
+            raise ValueError(f"Expected a stack of tensors of shape {dtype.shape}, got {stack.shape[1:]}")
+
+        flat = np.ascontiguousarray(stack).reshape(-1)
+        storage = pa.FixedSizeListArray.from_arrays(pa.array(flat, type=dtype.value_type), dtype.size)
+        return cls(storage, dtype=dtype)
+
+    def to_stack(self, na_value: Any = np.nan) -> np.ndarray:
+        """Convert the extension array to a single numpy array of shape ``(n, *shape)``
+
+        Without missing values the result is a read-only zero-copy view over
+        the arrow buffers. With missing values the data is copied, the result
+        dtype is widened as needed to hold ``na_value``, and the missing
+        tensors are filled with it.
+
+        Parameters
+        ----------
+        na_value : Any, default np.nan
+            Value to fill missing tensors with.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(len(self), *self.dtype.shape)``.
+        """
+        if len(self) == 0:
+            return np.empty((0, *self.dtype.shape), dtype=_numpy_value_dtype(self.dtype))
+
+        # combine_chunks() copies even for a single chunk, so avoid it when we can
+        if self._pa_array.num_chunks == 1:
+            combined = cast(pa.FixedShapeTensorArray, self._pa_array.chunk(0))
+        else:
+            combined = cast(pa.FixedShapeTensorArray, self._pa_array.combine_chunks())
+        stack = combined.to_numpy_ndarray()
+        if combined.null_count == 0:
+            return stack
+
+        # to_numpy_ndarray() silently returns garbage for null tensors, so fill them here
+        result_dtype = np.result_type(stack.dtype, np.min_scalar_type(na_value))
+        result = np.array(stack, dtype=result_dtype)
+        result[self.isna()] = na_value
+        return result
+
+    @classmethod
+    def from_arrow_ext_array(cls, array: ArrowExtensionArray, *, dtype: TensorDtype | None = None) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Create a TensorExtensionArray from pandas' ArrowExtensionArray
+
+        Parameters
+        ----------
+        array : ArrowExtensionArray
+            Array of the tensor type or of its fixed_size_list storage type.
+        dtype : TensorDtype, optional
+            Required when ``array`` is of the storage type.
+        """
+        return cls(array._pa_array, dtype=dtype)
+
+    def to_arrow_ext_array(self, storage: bool = False) -> ArrowExtensionArray:
+        """Convert the extension array to pandas' ArrowExtensionArray
+
+        Parameters
+        ----------
+        storage : bool, default False
+            If False (default), wrap the ``fixed_shape_tensor`` extension array,
+            otherwise wrap its ``fixed_size_list`` storage array.
+        """
+        return ArrowExtensionArray(self.storage if storage else self._pa_array)

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -115,10 +115,30 @@ def _storage_of(array: pa.ChunkedArray) -> pa.ChunkedArray:
     return pa.chunked_array([chunk.storage for chunk in array.iterchunks()], type=pa_type.storage_type)
 
 
+def _is_tensor_scalar(value: Any) -> bool:
+    """Whether a value is a pyarrow scalar of a fixed_shape_tensor type.
+
+    We check the type rather than ``isinstance(value, pa.FixedShapeTensorScalar)``
+    because that class is not exported by pyarrow before version 17.
+    """
+    return isinstance(value, pa.ExtensionScalar) and isinstance(value.type, pa.FixedShapeTensorType)
+
+
+def _tensor_scalar_to_numpy(scalar: pa.ExtensionScalar) -> np.ndarray:
+    """Read-only zero-copy numpy view of a valid fixed_shape_tensor scalar.
+
+    ``scalar.value`` is the fixed_size_list storage scalar, whose ``values``
+    are a slice of the flat child array. This is what
+    ``FixedShapeTensorScalar.to_numpy()`` does, but that method only exists
+    since pyarrow 17.
+    """
+    return np.asarray(scalar.value.values).reshape(tuple(scalar.type.shape))
+
+
 def _tensor_to_flat(value: Any, dtype: TensorDtype) -> np.ndarray:
     """Validate a single tensor against the dtype and return its values flattened in C order."""
-    if isinstance(value, pa.FixedShapeTensorScalar):
-        array = value.to_numpy()
+    if _is_tensor_scalar(value):
+        array = _tensor_scalar_to_numpy(value)
     elif isinstance(value, pa.Scalar):
         array = np.asarray(value.as_py())
         # A fixed_size_list scalar comes back flat
@@ -241,8 +261,8 @@ class TensorExtensionArray(ExtensionArray):
             first = next((value for value, na in zip(scalars, mask, strict=True) if not na), None)
             if first is None:
                 raise ValueError("Cannot infer TensorDtype from a sequence without non-missing values")
-            if isinstance(first, pa.FixedShapeTensorScalar):
-                first = first.to_numpy()
+            if _is_tensor_scalar(first):
+                first = _tensor_scalar_to_numpy(first)
             first = np.asarray(first)
             dtype = TensorDtype(pa.fixed_shape_tensor(pa.from_numpy_dtype(first.dtype), list(first.shape)))
 
@@ -589,7 +609,7 @@ class TensorExtensionArray(ExtensionArray):
         """Convert a tensor scalar to a read-only numpy view, or to na_value if it is null."""
         if not scalar.is_valid:
             return na_value
-        return cast(pa.FixedShapeTensorScalar, scalar).to_numpy()
+        return _tensor_scalar_to_numpy(scalar)
 
     def _is_scalar_value(self, value: Any) -> bool:
         """Whether a value passed to __setitem__ is a single tensor rather than a sequence of them."""

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -579,6 +579,8 @@ class TensorExtensionArray(ExtensionArray):
             return type(self)(storage, dtype=self.dtype)
 
         if (indices_array < 0).any():
+            if indices_array.min() < -len(self):
+                raise IndexError("out of bounds value in 'indices'.")
             # Don't modify in-place
             indices_array = np.copy(indices_array)
             indices_array[indices_array < 0] += len(self)
@@ -645,6 +647,13 @@ class TensorExtensionArray(ExtensionArray):
     def __array__(self, dtype=None, copy=None):
         """Convert the extension array to a numpy object array of tensors."""
         return self.to_numpy(dtype=dtype, copy=bool(copy))
+
+    # Adopted from ArrowExtensionArray
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        combined = self._pa_array.combine_chunks()
+        state["_pa_array"] = pa.chunked_array([combined], type=self.dtype.pyarrow_dtype)
+        return state
 
     # End of Additional magic methods #
 
@@ -748,9 +757,12 @@ class TensorExtensionArray(ExtensionArray):
         """Convert the extension array to a single numpy array of shape ``(n, *shape)``
 
         Without missing values the result is a read-only zero-copy view over
-        the arrow buffers. With missing values the data is copied, the result
+        the arrow buffers. With missing tensors the data is copied, the result
         dtype is widened as needed to hold ``na_value``, and the missing
-        tensors are filled with it.
+        tensors are filled with it. Missing *elements* inside otherwise
+        present tensors, which arrow allows, become ``NaN`` (with integer
+        tensors upcast to float), as numpy and pandas do for missing numeric
+        data.
 
         Parameters
         ----------
@@ -773,10 +785,12 @@ class TensorExtensionArray(ExtensionArray):
         return result
 
     def _values_block(self) -> np.ndarray:
-        """Read-only numpy view of shape ``(n, *shape)`` over the arrow buffers.
+        """Numpy array of shape ``(n, *shape)`` with the values of every tensor.
 
-        Zero-copy for a single chunk. Null tensors are present in the block
-        but hold arbitrary values, so callers must consult :meth:`isna`.
+        A read-only zero-copy view for a single chunk without missing elements.
+        Null tensors are present in the block but hold arbitrary values, so
+        callers must consult :meth:`isna`. Missing elements inside tensors
+        become ``NaN``, which copies and upcasts integer tensors to float.
         """
         if len(self) == 0:
             return np.empty((0, *self.dtype.shape), dtype=_numpy_value_dtype(self.dtype))
@@ -786,7 +800,19 @@ class TensorExtensionArray(ExtensionArray):
             combined = cast(pa.FixedShapeTensorArray, self._pa_array.chunk(0))
         else:
             combined = cast(pa.FixedShapeTensorArray, self._pa_array.combine_chunks())
-        return combined.to_numpy_ndarray()
+
+        # The flat values of exactly our rows: .values ignores a slice offset and .flatten()
+        # drops null tensors, so take the window by hand.
+        storage = combined.storage
+        size = self.dtype.size
+        values = storage.values.slice(storage.offset * size, len(storage) * size)
+        if values.null_count == 0:
+            return combined.to_numpy_ndarray()
+
+        # to_numpy_ndarray() ignores the validity bitmap of the elements and would return
+        # arbitrary values for them. pyarrow's to_numpy() fills them with NaN instead, upcasting
+        # integers to float64, as numpy and pandas do for missing numeric data.
+        return values.to_numpy(zero_copy_only=False).reshape(len(storage), *self.dtype.shape)
 
     @classmethod
     def from_arrow_ext_array(cls, array: ArrowExtensionArray, *, dtype: TensorDtype | None = None) -> Self:  # type: ignore[name-defined] # noqa: F821

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -53,7 +53,7 @@ from pandas.core.indexers import (  # type: ignore[attr-defined]
     validate_indices,
 )
 
-from nested_pandas.series.ext_array import replace_with_mask
+from nested_pandas.series.utils import replace_with_mask
 from nested_pandas.tensors.dtype import TensorDtype
 
 __all__ = ["TensorExtensionArray"]

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -252,7 +252,12 @@ class TensorExtensionArray(ExtensionArray):
         if isinstance(scalars, pa.Array | pa.ChunkedArray):
             return cls(scalars, dtype=dtype)
         if isinstance(scalars, np.ndarray) and scalars.dtype != np.object_ and scalars.ndim >= 2:
-            return cls.from_stack(scalars, dtype=dtype)
+            if dtype is not None and scalars.ndim == dtype.ndim:
+                # A single tensor (possibly of the wrong shape, which is reported below), e.g. pandas
+                # broadcasting a "scalar", rather than a stack of them
+                scalars = [scalars]
+            else:
+                return cls.from_stack(scalars, dtype=dtype)
 
         scalars = list(scalars)
         mask = np.array([_is_na(value) for value in scalars], dtype=bool)
@@ -284,16 +289,15 @@ class TensorExtensionArray(ExtensionArray):
 
         if isinstance(item, np.ndarray):
             if len(item) == 0:
-                return type(self)(pa.chunked_array([], type=self.dtype.pyarrow_dtype), dtype=self.dtype)
-            pa_item = pa.array(item)
-            if item.dtype.kind in "iu":
-                return type(self)(self._pa_array.take(pa_item), dtype=self.dtype)
-            if item.dtype.kind == "b":
-                return type(self)(self._pa_array.filter(pa_item), dtype=self.dtype)
-            # It should be covered by check_array_indexer above
-            raise IndexError(
-                "Only integers, slices and integer or boolean arrays are valid indices."
-            )  # pragma: no cover
+                pa_array = pa.chunked_array([], type=self.dtype.pyarrow_dtype)
+            elif item.dtype.kind in "iu":
+                pa_array = self._pa_array.take(pa.array(item))
+            elif item.dtype.kind == "b":
+                pa_array = self._pa_array.filter(pa.array(item))
+            else:  # pragma: no cover
+                # It should be covered by check_array_indexer above
+                raise IndexError("Only integers, slices and integer or boolean arrays are valid indices.")
+            return self._wrap_result(pa_array)
 
         if isinstance(item, tuple):
             item = unpack_tuple_and_ellipses(item)
@@ -301,13 +305,28 @@ class TensorExtensionArray(ExtensionArray):
         if item is Ellipsis:
             item = slice(None)
 
+        if not isinstance(item, int | np.integer | slice):
+            raise IndexError(
+                "only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or "
+                "boolean arrays are valid indices"
+            )
+
         scalar_or_array = self._pa_array[item]
         if isinstance(scalar_or_array, pa.Scalar):
             return self._scalar_to_numpy(scalar_or_array)
         # Logically, it must be a pa.ChunkedArray if it is not a scalar
-        return type(self)(cast(pa.ChunkedArray, scalar_or_array), dtype=self.dtype)
+        return self._wrap_result(cast(pa.ChunkedArray, scalar_or_array))
+
+    def _wrap_result(self, pa_array: pa.ChunkedArray) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Wrap a selection from this array, carrying over the dtype and the read-only flag."""
+        result = type(self)(pa_array, dtype=self.dtype)
+        result._readonly = self._readonly
+        return result
 
     def __setitem__(self, key, value) -> None:
+        if self._readonly:
+            raise ValueError("Cannot modify read-only array")
+
         key = check_array_indexer(self, key)
 
         if isinstance(key, tuple):
@@ -321,19 +340,25 @@ class TensorExtensionArray(ExtensionArray):
         if len(key) == 0:
             return
 
-        argsort: np.ndarray | None = None
+        # For integer keys, `value_index` maps each set position (in mask order) to the element
+        # of a sequence `value` to take, so that duplicate keys follow numpy: the last one wins.
+        value_index: np.ndarray | None = None
         if key.dtype.kind in "iu":
-            _, argsort = np.unique(key, return_index=True)
+            key = np.where(key < 0, key + len(self), key)
+            if key.min() < 0 or key.max() >= len(self):
+                raise IndexError("index out of bounds")
+            _, last_reversed = np.unique(key[::-1], return_index=True)
+            value_index = len(key) - 1 - last_reversed
             np_mask = np.zeros(len(self), dtype=np.bool_)
             np_mask[key] = True
             pa_mask = pa.array(np_mask)
+            n_values = len(key)
         elif key.dtype.kind == "b":
             pa_mask = pa.array(key)
+            n_values = int(key.sum())
         # Should be covered by check_array_indexer
         else:  # pragma: no cover
-            raise IndexError(
-                "Only integers, slices and integer or boolean arrays are valid indices."
-            )  # pragma: no cover
+            raise IndexError("Only integers, slices and integer or boolean arrays are valid indices.")
 
         n_set = pc.sum(pa_mask).as_py() or 0
 
@@ -343,12 +368,12 @@ class TensorExtensionArray(ExtensionArray):
             value_storage: pa.Array | pa.ChunkedArray = pa.repeat(scalar, n_set)
         else:
             value_storage = type(self)._from_sequence(value, dtype=self.dtype).storage
-            if len(value_storage) != n_set:
+            if len(value_storage) != n_values:
                 raise ValueError(
-                    f"Cannot set {n_set} elements from a sequence of length {len(value_storage)}"
+                    f"Cannot set {n_values} elements from a sequence of length {len(value_storage)}"
                 )
-            if argsort is not None:
-                value_storage = value_storage.take(argsort)
+            if value_index is not None:
+                value_storage = value_storage.take(value_index)
 
         # pa.compute.replace_with_mask() and if_else() have no kernels for the extension type,
         # so we work on the fixed_size_list storage and wrap it back.
@@ -628,6 +653,31 @@ class TensorExtensionArray(ExtensionArray):
         """Return a new ExtensionArray with missing tensors removed."""
         return type(self)(pc.drop_null(self._pa_array), dtype=self.dtype)
 
+    def shift(self, periods: int = 1, fill_value: Any = None) -> Self:  # type: ignore[name-defined] # noqa: F821
+        """Shift values by the desired number, filling with a tensor or with missing values.
+
+        The base class implementation checks ``isna(fill_value)``, which is
+        ambiguous for an ndarray fill value, so it is reimplemented here.
+
+        Parameters
+        ----------
+        periods : int, default 1
+            The number of periods to shift. Negative values shift towards the start.
+        fill_value : np.ndarray, None or pd.NA, default None
+            The tensor to fill the vacated positions with, or missing if None or pd.NA.
+
+        Returns
+        -------
+        TensorExtensionArray
+        """
+        if not len(self) or periods == 0:
+            return self.copy()
+
+        n_fill = min(abs(periods), len(self))
+        fill = type(self)._from_sequence([fill_value] * n_fill, dtype=self.dtype)
+        parts = [fill, self[: len(self) - n_fill]] if periods > 0 else [self[n_fill:], fill]
+        return self._concat_same_type(parts)
+
     # End of ExtensionArray overrides #
 
     # Additional magic methods #
@@ -646,6 +696,9 @@ class TensorExtensionArray(ExtensionArray):
 
     def __array__(self, dtype=None, copy=None):
         """Convert the extension array to a numpy object array of tensors."""
+        if copy is False:
+            # The object array is always newly built, so a no-copy conversion cannot be honored
+            raise ValueError("Unable to avoid copy while creating an array as requested.")
         return self.to_numpy(dtype=dtype, copy=bool(copy))
 
     # Adopted from ArrowExtensionArray

--- a/src/nested_pandas/tensors/ext_array.py
+++ b/src/nested_pandas/tensors/ext_array.py
@@ -194,7 +194,9 @@ class TensorExtensionArray(ExtensionArray):
         if isinstance(values.type, pa.FixedShapeTensorType):
             if dtype is None:
                 dtype = TensorDtype(values.type)
-            elif dtype.pyarrow_dtype != values.type:
+            # pyarrow compares tensor types with and without an identity permutation equal, but we
+            # want the stored array to have exactly the dtype's type, so check the permutation too
+            if dtype.pyarrow_dtype != values.type or values.type.permutation is not None:
                 values = self._wrap_storage(_storage_of(values), dtype)
         elif pa.types.is_fixed_size_list(values.type):
             if dtype is None:
@@ -362,9 +364,13 @@ class TensorExtensionArray(ExtensionArray):
 
         n_set = pc.sum(pa_mask).as_py() or 0
 
+        # When nothing is selected, e.g. by an empty slice or an all-False mask, we still validate
+        # the value, but return before pa.repeat() and replace_with_mask(), which need elements.
         if self._is_scalar_value(value):
             # Our replace_with_mask implementation doesn't work with scalars, so broadcast
             scalar = self._scalar_storage(value)
+            if n_set == 0:
+                return
             value_storage: pa.Array | pa.ChunkedArray = pa.repeat(scalar, n_set)
         else:
             value_storage = type(self)._from_sequence(value, dtype=self.dtype).storage
@@ -372,6 +378,8 @@ class TensorExtensionArray(ExtensionArray):
                 raise ValueError(
                     f"Cannot set {n_values} elements from a sequence of length {len(value_storage)}"
                 )
+            if n_set == 0:
+                return
             if value_index is not None:
                 value_storage = value_storage.take(value_index)
 

--- a/tests/nested_pandas/series/test_ext_array.py
+++ b/tests/nested_pandas/series/test_ext_array.py
@@ -12,7 +12,8 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from nested_pandas import NestedDtype
 from nested_pandas.datasets import generate_data
 from nested_pandas.nestedframe.core import NestedFrame
-from nested_pandas.series.ext_array import NestedExtensionArray, convert_df_to_pa_scalar, replace_with_mask
+from nested_pandas.series.ext_array import NestedExtensionArray, convert_df_to_pa_scalar
+from nested_pandas.series.utils import replace_with_mask
 
 
 def test_replace_with_mask():

--- a/tests/nested_pandas/tensors/conftest.py
+++ b/tests/nested_pandas/tensors/conftest.py
@@ -1,0 +1,301 @@
+"""Fixtures for the tensor tests, including those pandas' extension test suite expects.
+
+pandas ships a conformance suite for third-party extension arrays in
+``pandas.tests.extension.base``. Its tests are driven by fixtures that pandas
+defines in its own ``conftest.py`` files, which are not importable, so the ones
+the tensor suites use are replicated here with the same names and semantics.
+"""
+
+import operator
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+from tensor_test_utils import TENSOR_SHAPE, tensor, tensor_stack
+
+from nested_pandas import TensorDtype
+from nested_pandas.tensors.ext_array import TensorExtensionArray
+
+# Expected failures in pandas' conformance suite (test_pandas_extension_suite.py) #
+
+PANDAS_NDARRAY_SCALAR = (
+    "pandas treats an ndarray value as a sequence, not a scalar, before the extension array is consulted"
+)
+NOT_HASHABLE = "tensors are not hashable"
+NO_VIEWS = (
+    "an arrow-backed array cannot share buffers with a view (pandas' ArrowExtensionArray xfails this too)"
+)
+NO_ORDERING = "tensors have no ordering"
+
+XFAIL_STRICT = {
+    # Series/DataFrame __setitem__ and fillna inspect an ndarray value themselves and reject it,
+    # or misread a 2-d tensor as a (N, 1) column, before our __setitem__ runs. The array-level
+    # operations work, see test_tensor_ext_array.py.
+    "test_series_constructor_scalar_with_index": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_scalar": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_loc_scalar_mixed": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_loc_scalar_single": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_loc_scalar_multiple_homogoneous": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_iloc_scalar_mixed": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_iloc_scalar_single": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_iloc_scalar_multiple_homogoneous": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_loc_iloc_slice": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_mask_broadcast": PANDAS_NDARRAY_SCALAR,
+    "test_setitem_with_expansion_row": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_scalar": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_series": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_frame": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_no_op_returns_copy": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_readonly": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_copy_frame": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_copy_series": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_limit_frame": PANDAS_NDARRAY_SCALAR,
+    "test_fillna_limit_series": PANDAS_NDARRAY_SCALAR,
+    # Hash tables
+    "test_unique": NOT_HASHABLE,
+    "test_duplicated": NOT_HASHABLE,
+    "test_value_counts_with_normalize": NOT_HASHABLE,
+    "test_hash_pandas_object": NOT_HASHABLE,
+    "test_hash_pandas_object_works": NOT_HASHABLE,
+    "test_factorize_empty": NOT_HASHABLE,
+    "test_merge_on_extension_array": NOT_HASHABLE,
+    "test_merge_on_extension_array_duplicates": NOT_HASHABLE,
+    # Ordering
+    "test_combine_le": NO_ORDERING,
+}
+"""Suite tests that must fail, by test function name."""
+
+XFAIL_NO_RUN = {
+    "test_view": NO_VIEWS,
+    "test_ravel": NO_VIEWS,
+    "test_transpose": NO_VIEWS,
+    "test_setitem_preserves_views": NO_VIEWS,
+}
+"""Suite tests that are not run at all, as pandas does for its own arrow array."""
+
+XFAIL_FOR_PARAM = {
+    # Broadcasting one tensor to several positions of a Series: pandas length-checks the ndarray.
+    # Series.__setitem__ with a single position and with a sequence of tensors both work.
+    "test_setitem_sequence_broadcasts": ("box_in_series", True, PANDAS_NDARRAY_SCALAR),
+    "test_setitem_integer_array": ("box_in_series", True, PANDAS_NDARRAY_SCALAR),
+    "test_setitem_mask": ("box_in_series", True, PANDAS_NDARRAY_SCALAR),
+    "test_setitem_mask_boolean_array_with_na": ("box_in_series", True, PANDAS_NDARRAY_SCALAR),
+    "test_setitem_slice": ("box_in_series", True, PANDAS_NDARRAY_SCALAR),
+    # value_counts only hashes when there is more than one distinct element
+    "test_value_counts": ("all_data", "data", NOT_HASHABLE),
+}
+"""Suite tests that must fail only for one value of one parameter: name -> (param, value, reason)."""
+
+
+def pytest_collection_modifyitems(items):
+    """Mark the pandas conformance tests that cannot pass for tensors as xfail.
+
+    Adding markers here rather than overriding the tests keeps their
+    parametrization intact.
+    """
+    for item in items:
+        if "test_pandas_extension_suite.py" not in item.nodeid:
+            continue
+        name = getattr(item, "originalname", None) or item.name
+        if name in XFAIL_STRICT:
+            item.add_marker(pytest.mark.xfail(reason=XFAIL_STRICT[name], strict=True))
+        elif name in XFAIL_NO_RUN:
+            item.add_marker(pytest.mark.xfail(reason=XFAIL_NO_RUN[name], run=False))
+        elif name in XFAIL_FOR_PARAM:
+            param, value, reason = XFAIL_FOR_PARAM[name]
+            params = getattr(getattr(item, "callspec", None), "params", {})
+            if params.get(param) == value:
+                item.add_marker(pytest.mark.xfail(reason=reason, strict=True))
+
+
+# Fixtures with the names and semantics of pandas/tests/extension/conftest.py #
+
+
+@pytest.fixture
+def dtype():
+    """The dtype the pandas suite is run against."""
+    return TensorDtype(pa.fixed_shape_tensor(pa.float64(), list(TENSOR_SHAPE)))
+
+
+@pytest.fixture
+def data(dtype):
+    """Length-10 array without missing values, where data[0] != data[1], as the pandas suite expects."""
+    return TensorExtensionArray.from_stack(tensor_stack(range(10)), dtype=dtype)
+
+
+@pytest.fixture
+def data_for_twos(dtype):
+    """Length-100 array where every element is 2; only meaningful for numeric dtypes."""
+    pytest.skip(f"{dtype} is not a numeric dtype")
+
+
+@pytest.fixture
+def data_missing(dtype):
+    """Length-2 array of [missing, valid]."""
+    return TensorExtensionArray.from_sequence([None, tensor(1)], dtype=dtype)
+
+
+@pytest.fixture(params=["data", "data_missing"])
+def all_data(request, data, data_missing):
+    """Parametrized fixture giving both ``data`` and ``data_missing``."""
+    if request.param == "data":
+        return data
+    return data_missing
+
+
+@pytest.fixture
+def data_repeated(data):
+    """Generator yielding ``data`` repeatedly."""
+
+    def gen(count):
+        for _ in range(count):
+            yield data
+
+    return gen
+
+
+@pytest.fixture
+def data_for_sorting():
+    """Length-3 array with a known ordering; tensors have none."""
+    pytest.skip("tensors have no ordering")
+
+
+@pytest.fixture
+def data_missing_for_sorting():
+    """Length-3 array with a known ordering and a missing value; tensors have no ordering."""
+    pytest.skip("tensors have no ordering")
+
+
+@pytest.fixture
+def na_cmp():
+    """Binary operator comparing two NA values; pd.NA is a singleton."""
+    return operator.is_
+
+
+@pytest.fixture
+def na_value(dtype):
+    """The scalar missing value for the dtype."""
+    return dtype.na_value
+
+
+@pytest.fixture
+def data_for_grouping():
+    """Data for grouping tests; requires hashable values, which tensors are not."""
+    pytest.skip("tensors are not hashable, so they cannot be grouped")
+
+
+@pytest.fixture(params=[True, False])
+def box_in_series(request):
+    """Whether to box the data in a Series."""
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        lambda x: 1,
+        lambda x: [1] * len(x),
+        lambda x: pd.Series([1] * len(x)),
+        lambda x: x,
+    ],
+    ids=["scalar", "list", "series", "object"],
+)
+def groupby_apply_op(request):
+    """Functions to test groupby.apply()."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_frame(request):
+    """Whether to convert to a DataFrame."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_series(request):
+    """Whether to convert to a Series."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def use_numpy(request):
+    """Whether to use numpy functions rather than pandas methods."""
+    return request.param
+
+
+@pytest.fixture(params=["ffill", "bfill"])
+def fillna_method(request):
+    """Method parameter for fillna tests."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_array(request):
+    """Whether to convert to an ExtensionArray."""
+    return request.param
+
+
+@pytest.fixture
+def invalid_scalar(data):
+    """A scalar that cannot be held by this extension array."""
+    return object.__new__(object)
+
+
+# Fixtures with the names and semantics of pandas/conftest.py #
+
+
+@pytest.fixture(params=[True, False])
+def skipna(request):
+    """Boolean skipna parameter."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def ascending(request):
+    """Boolean ascending parameter."""
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def dropna(request):
+    """Boolean dropna parameter."""
+    return request.param
+
+
+@pytest.fixture(params=[None, "ignore"])
+def na_action(request):
+    """na_action parameter for map."""
+    return request.param
+
+
+@pytest.fixture(params=[None, lambda x: x])
+def sort_by_key(request):
+    """Key parameter for sort_values."""
+    return request.param
+
+
+@pytest.fixture(params=[operator.eq, operator.ne], ids=["eq", "ne"])
+def comparison_op(request):
+    """Comparison operators the tensor array supports; ordering comparisons are not defined."""
+    return request.param
+
+
+@pytest.fixture
+def using_infer_string() -> bool:
+    """Whether pandas infers the string dtype for object data."""
+    return pd.options.future.infer_string is True
+
+
+@pytest.fixture
+def using_nan_is_na() -> bool:
+    """Whether pandas treats NaN as missing for nullable dtypes."""
+    try:
+        return bool(pd.get_option("mode.nan_is_na"))
+    except (pd.errors.OptionError, KeyError):
+        return True
+
+
+@pytest.fixture(params=[True, False])
+def performance_warning(request):
+    """Whether PerformanceWarnings are enabled, yielding the warning class or False."""
+    with pd.option_context("mode.performance_warnings", request.param):
+        yield pd.errors.PerformanceWarning if request.param else False

--- a/tests/nested_pandas/tensors/conftest.py
+++ b/tests/nested_pandas/tensors/conftest.py
@@ -190,20 +190,6 @@ def box_in_series(request):
     return request.param
 
 
-@pytest.fixture(
-    params=[
-        lambda x: 1,
-        lambda x: [1] * len(x),
-        lambda x: pd.Series([1] * len(x)),
-        lambda x: x,
-    ],
-    ids=["scalar", "list", "series", "object"],
-)
-def groupby_apply_op(request):
-    """Functions to test groupby.apply()."""
-    return request.param
-
-
 @pytest.fixture(params=[True, False])
 def as_frame(request):
     """Whether to convert to a DataFrame."""
@@ -280,22 +266,9 @@ def comparison_op(request):
 
 
 @pytest.fixture
-def using_infer_string() -> bool:
-    """Whether pandas infers the string dtype for object data."""
-    return pd.options.future.infer_string is True
-
-
-@pytest.fixture
 def using_nan_is_na() -> bool:
     """Whether pandas treats NaN as missing for nullable dtypes."""
     try:
         return bool(pd.get_option("mode.nan_is_na"))
     except (pd.errors.OptionError, KeyError):
         return True
-
-
-@pytest.fixture(params=[True, False])
-def performance_warning(request):
-    """Whether PerformanceWarnings are enabled, yielding the warning class or False."""
-    with pd.option_context("mode.performance_warnings", request.param):
-        yield pd.errors.PerformanceWarning if request.param else False

--- a/tests/nested_pandas/tensors/tensor_test_utils.py
+++ b/tests/nested_pandas/tensors/tensor_test_utils.py
@@ -1,0 +1,16 @@
+"""Helpers for building tensor test data, shared by conftest.py and the test modules."""
+
+import numpy as np
+
+TENSOR_SHAPE = (2, 3)
+"""Shape of the tensors in the shared fixtures"""
+
+
+def tensor(value: float) -> np.ndarray:
+    """A distinct ``TENSOR_SHAPE`` tensor for a scalar, used to build fixture data."""
+    return value + np.arange(np.prod(TENSOR_SHAPE), dtype=np.float64).reshape(TENSOR_SHAPE) / 10
+
+
+def tensor_stack(values) -> np.ndarray:
+    """A ``(len(values), *TENSOR_SHAPE)`` stack of :func:`tensor` for each value."""
+    return np.stack([tensor(value) for value in values])

--- a/tests/nested_pandas/tensors/test_pandas_extension_suite.py
+++ b/tests/nested_pandas/tensors/test_pandas_extension_suite.py
@@ -110,6 +110,11 @@ class TestGetitem(base.BaseGetitemTests):
         with pytest.raises(ValueError, match=msg):
             s.item()
 
+    # ExtensionArray.item() and its suite tests were added in a pandas 3.0 patch release, so these
+    # two overrides are only run where the base suite defines them.
+    @pytest.mark.skipif(
+        not hasattr(base.BaseGetitemTests, "test_array_item"), reason="ExtensionArray.item not in this pandas"
+    )
     def test_array_item(self, data):
         """Array.item on a length-1 array."""
         arr = data[:1]
@@ -121,6 +126,10 @@ class TestGetitem(base.BaseGetitemTests):
         with pytest.raises(ValueError, match=msg):
             data[:0].item()
 
+    @pytest.mark.skipif(
+        not hasattr(base.BaseGetitemTests, "test_array_item_with_index"),
+        reason="ExtensionArray.item not in this pandas",
+    )
     def test_array_item_with_index(self, data):
         """Array.item with an index."""
         assert_tensor_equal(data.item(0), data[0])

--- a/tests/nested_pandas/tensors/test_pandas_extension_suite.py
+++ b/tests/nested_pandas/tensors/test_pandas_extension_suite.py
@@ -1,0 +1,315 @@
+"""Run pandas' extension array conformance suite against TensorExtensionArray.
+
+The suites live in ``pandas.tests.extension.base`` and are driven by the
+fixtures in ``conftest.py``. Suites that make no sense for tensors are left
+out entirely: arithmetic (for now), reductions and accumulations (tensors are not
+numeric scalars), groupby (tensors are not hashable), parsing (tensors are
+not read from CSV) and unary ufuncs.
+
+Within the included suites, tests whose assertions compare elements with
+``==`` are overridden below with the same logic using ``np.array_equal``,
+because a tensor element is an ndarray and ``==`` on it is elementwise.
+Tests that cannot pass for tensors are marked xfail from ``conftest.py``,
+which lists the reasons: pandas treating an ndarray value as a sequence
+rather than a scalar, elements not being hashable, and arrow arrays not
+supporting numpy-style views.
+"""
+
+import operator
+
+import numpy as np
+import pandas as pd
+import pandas._testing as tm
+import pytest
+from pandas.tests.extension import base
+
+
+def assert_tensor_equal(left, right) -> None:
+    """Assert two tensor elements (ndarrays) are equal."""
+    assert np.array_equal(left, right)
+
+
+def assert_tensor_not_equal(left, right) -> None:
+    """Assert two tensor elements (ndarrays) differ."""
+    assert not np.array_equal(left, right)
+
+
+class TestConstructors(base.BaseConstructorsTests):
+    """Constructing Series and DataFrames from the array, dtype strings and scalars."""
+
+
+class TestGetitem(base.BaseGetitemTests):
+    """Indexing, slicing, take and iteration."""
+
+    def test_get(self, data):
+        """Series.get with scalar, list and slice keys."""
+        s = pd.Series(data, index=[2 * i for i in range(len(data))])
+        assert_tensor_equal(s.get(4), s.iloc[2])
+
+        result = s.get([4, 6])
+        expected = s.iloc[[2, 3]]
+        tm.assert_series_equal(result, expected)
+
+        result = s.get(slice(2))
+        expected = s.iloc[[0, 1]]
+        tm.assert_series_equal(result, expected)
+
+        assert s.get(-1) is None
+        assert s.get(s.index.max() + 1) is None
+
+        s = pd.Series(data[:6], index=list("abcdef"))
+        assert_tensor_equal(s.get("c"), s.iloc[2])
+
+        result = s.get(slice("b", "d"))
+        expected = s.iloc[[1, 2, 3]]
+        tm.assert_series_equal(result, expected)
+
+        result = s.get("Z")
+        assert result is None
+
+        # As of 3.0, getitem with int keys treats them as labels
+        assert s.get(4) is None
+        assert s.get(-1) is None
+        assert s.get(len(s)) is None
+
+        s = pd.Series(data)
+        with tm.assert_produces_warning(None):
+            s2 = s[::2]
+        assert s2.get(1) is None
+
+    def test_take_sequence(self, data):
+        """Series positional take with a list."""
+        result = pd.Series(data)[[0, 1, 3]]
+        assert_tensor_equal(result.iloc[0], data[0])
+        assert_tensor_equal(result.iloc[1], data[1])
+        assert_tensor_equal(result.iloc[2], data[3])
+
+    def test_take(self, data, na_value, na_cmp):
+        """Array take with and without allow_fill."""
+        result = data.take([0, -1])
+        assert result.dtype == data.dtype
+        assert_tensor_equal(result[0], data[0])
+        assert_tensor_equal(result[1], data[-1])
+
+        result = data.take([0, -1], allow_fill=True, fill_value=na_value)
+        assert_tensor_equal(result[0], data[0])
+        assert na_cmp(result[1], na_value)
+
+        with pytest.raises(IndexError, match="out of bounds"):
+            data.take([len(data) + 1])
+
+    def test_item(self, data):
+        """Series.item on a length-1 Series."""
+        s = pd.Series(data)
+        result = s[:1].item()
+        assert_tensor_equal(result, data[0])
+
+        msg = "can only convert an array of size 1 to a Python scalar"
+        with pytest.raises(ValueError, match=msg):
+            s[:0].item()
+        with pytest.raises(ValueError, match=msg):
+            s.item()
+
+    def test_array_item(self, data):
+        """Array.item on a length-1 array."""
+        arr = data[:1]
+        assert_tensor_equal(arr.item(), data[0])
+
+        msg = "can only convert an array of size 1 to a Python scalar"
+        with pytest.raises(ValueError, match=msg):
+            data[:2].item()
+        with pytest.raises(ValueError, match=msg):
+            data[:0].item()
+
+    def test_array_item_with_index(self, data):
+        """Array.item with an index."""
+        assert_tensor_equal(data.item(0), data[0])
+        assert_tensor_equal(data.item(-1), data[-1])
+
+        with tm.external_error_raised(IndexError):
+            data.item(len(data))
+
+        msg = "index must be an integer"
+        with pytest.raises(TypeError, match=msg):
+            data.item([0])
+
+
+class TestSetitem(base.BaseSetitemTests):
+    """Assignment with scalars, sequences, masks and indexers."""
+
+    def test_is_immutable(self, data):
+        """The array is mutable."""
+        assert not data.dtype._is_immutable
+        data[0] = data[1]
+        assert_tensor_equal(data[0], data[1])
+
+    def test_setitem_scalar_series(self, data, box_in_series):
+        """Assigning one element to one position."""
+        if box_in_series:
+            data = pd.Series(data)
+        data[0] = data[1]
+        assert_tensor_equal(data[0], data[1])
+
+    def test_setitem_sequence(self, data, box_in_series):
+        """Assigning a sequence of elements to integer positions."""
+        if box_in_series:
+            data = pd.Series(data)
+        original = data.copy()
+        data[[0, 1]] = [data[1], data[0]]
+        assert_tensor_equal(data[0], original[1])
+        assert_tensor_equal(data[1], original[0])
+
+    def test_setitem_sequence_broadcasts(self, data, box_in_series):
+        """Broadcasting one element to several positions."""
+        if box_in_series:
+            data = pd.Series(data)
+        data[[0, 1]] = data[2]
+        assert_tensor_equal(data[0], data[2])
+        assert_tensor_equal(data[1], data[2])
+
+    @pytest.mark.parametrize("as_callable", [True, False])
+    @pytest.mark.parametrize("setter", ["loc", None])
+    def test_setitem_mask_aligned(self, data, as_callable, setter):
+        """Assigning with an aligned boolean Series mask."""
+        ser = pd.Series(data)
+        mask = np.zeros(len(data), dtype=bool)
+        mask[:2] = True
+
+        mask2 = (lambda x: mask) if as_callable else mask
+        target = getattr(ser, setter) if setter else ser
+
+        target[mask2] = data[5:7]
+
+        ser[mask2] = data[5:7]
+        assert_tensor_equal(ser[0], data[5])
+        assert_tensor_equal(ser[1], data[6])
+
+
+class TestInterface(base.BaseInterfaceTests):
+    """The ExtensionArray interface: len, ndim, nbytes, isna, copy, array conversion."""
+
+    def test_array_interface(self, data):
+        """np.array of the extension array."""
+        result = np.array(data)
+        assert_tensor_equal(result[0], data[0])
+
+        result = np.array(data, dtype=object)
+        expected = np.empty(len(data), dtype=object)
+        expected[:] = list(data)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_copy(self, data):
+        """copy gives an independent array."""
+        assert_tensor_not_equal(data[0], data[1])
+        result = data.copy()
+        data[1] = data[0]
+        assert_tensor_not_equal(result[1], result[0])
+
+    def test_tolist(self, data):
+        """tolist gives the elements."""
+        result = data.tolist()
+        expected = list(data)
+        assert isinstance(result, list)
+        assert len(result) == len(expected)
+        for left, right in zip(result, expected, strict=True):
+            assert_tensor_equal(left, right)
+
+
+class TestMethods(base.BaseMethodsTests):
+    """General methods: shift, fillna, unique, factorize, where, insert and friends."""
+
+    def test_shift_0_periods(self, data):
+        """shift(0) returns a copy, not the same object."""
+        result = data.shift(0)
+        assert_tensor_not_equal(data[0], data[1])
+        data[0] = data[1]
+        assert_tensor_not_equal(result[0], result[1])
+
+    def test_where_series(self, data, na_value, as_frame):
+        """Series.where with a boolean condition, and with `other`."""
+        assert_tensor_not_equal(data[0], data[1])
+        cls = type(data)
+        a, b = data[:2]
+
+        orig = pd.Series(cls._from_sequence([a, a, b, b], dtype=data.dtype))
+        ser = orig.copy()
+        cond = np.array([True, True, False, False])
+
+        if as_frame:
+            ser = ser.to_frame(name="a")
+            cond = cond.reshape(-1, 1)
+
+        result = ser.where(cond)
+        expected = pd.Series(cls._from_sequence([a, a, na_value, na_value], dtype=data.dtype))
+
+        if as_frame:
+            expected = expected.to_frame(name="a")
+        tm.assert_equal(result, expected)
+
+        ser.mask(~cond, inplace=True)
+        tm.assert_equal(ser, expected)
+
+        # array other
+        ser = orig.copy()
+        if as_frame:
+            ser = ser.to_frame(name="a")
+        cond = np.array([True, False, True, True])
+        other = cls._from_sequence([a, b, a, b], dtype=data.dtype)
+        if as_frame:
+            other = pd.DataFrame({"a": other})
+            cond = pd.DataFrame({"a": cond})
+        result = ser.where(cond, other)
+        expected = pd.Series(cls._from_sequence([a, b, b, b], dtype=data.dtype))
+        if as_frame:
+            expected = expected.to_frame(name="a")
+        tm.assert_equal(result, expected)
+
+        ser.mask(~cond, other, inplace=True)
+        tm.assert_equal(ser, expected)
+
+
+class TestMissing(base.BaseMissingTests):
+    """Missing value handling: isna, dropna, fillna."""
+
+
+class TestPrinting(base.BasePrintingTests):
+    """repr of arrays, Series and DataFrames."""
+
+
+class TestReshaping(base.BaseReshapingTests):
+    """concat, merge, stack, unstack, transpose and ravel."""
+
+
+class TestCasting(base.BaseCastingTests):
+    """astype to object, string and self."""
+
+    def test_tolist(self, data):
+        """Series.tolist gives the elements."""
+        result = pd.Series(data).tolist()
+        expected = list(data)
+        assert len(result) == len(expected)
+        for left, right in zip(result, expected, strict=True):
+            assert_tensor_equal(left, right)
+
+
+class TestIndex(base.BaseIndexTests):
+    """Holding the array in an Index."""
+
+
+class TestComparisonOps(base.BaseComparisonOpsTests):
+    """== and != against scalars and arrays."""
+
+    def _compare_other(self, ser: pd.Series, data, op, other):
+        """Check the vectorized comparison against a pointwise np.array_equal.
+
+        The base implementation builds the expectation with ``Series.combine``,
+        which applies the operator to pairs of ndarrays and gets elementwise
+        results rather than one boolean per row.
+        """
+        result = op(ser, other)
+        others = list(other) if isinstance(other, pd.Series | pd.Index) else [other] * len(ser)
+        equal = [np.array_equal(left, right) for left, right in zip(ser, others, strict=True)]
+        if op is operator.ne:
+            equal = [not value for value in equal]
+        expected = pd.Series(equal, dtype="boolean", index=ser.index, name=ser.name)
+        tm.assert_series_equal(result, expected)

--- a/tests/nested_pandas/tensors/test_tensor_dtype.py
+++ b/tests/nested_pandas/tensors/test_tensor_dtype.py
@@ -94,9 +94,8 @@ def test_identity_permutation_is_normalized(shape, dim_names):
         pa.float64(), shape, dim_names=dim_names, permutation=permutation
     )
     without_permutation = pa.fixed_shape_tensor(pa.float64(), shape, dim_names=dim_names)
-    # pyarrow itself compares these equal but hashes them differently
+    # pyarrow compares these equal (but, at least in 16-19, hashes them differently)
     assert with_permutation == without_permutation
-    assert hash(with_permutation) != hash(without_permutation)
 
     dtype = TensorDtype(with_permutation)
     expected = TensorDtype(without_permutation)

--- a/tests/nested_pandas/tensors/test_tensor_dtype.py
+++ b/tests/nested_pandas/tensors/test_tensor_dtype.py
@@ -8,6 +8,7 @@ from pandas.core.dtypes.cast import find_common_type
 from pandas.tests.extension import base
 
 from nested_pandas import TensorDtype
+from nested_pandas.tensors.ext_array import TensorExtensionArray
 
 
 class _NotATensorType(pa.ExtensionType):
@@ -341,20 +342,17 @@ class TestPandasBaseDtype(base.BaseDtypeTests):
         """The dtype instance the pandas suite is run against."""
         return TensorDtype(pa.fixed_shape_tensor(pa.float64(), [2, 3]))
 
-    # TODO: remove these overrides and provide the ``data`` and ``data_missing`` fixtures
-    # once TensorExtensionArray is merged.
-    @pytest.mark.skip(reason="Requires TensorExtensionArray")
-    def test_array_type(self):
-        """Skipped until the extension array exists."""
+    @pytest.fixture
+    def data(self, dtype):
+        """Length-100 array without missing values, as the pandas suite expects."""
+        return TensorExtensionArray.from_stack(np.arange(600.0).reshape(100, 2, 3), dtype=dtype)
 
-    @pytest.mark.skip(reason="Requires TensorExtensionArray")
-    def test_check_dtype(self):
-        """Skipped until the extension array exists."""
+    @pytest.fixture
+    def data_missing(self, dtype):
+        """Length-2 array of [missing, valid], as the pandas suite expects."""
+        return TensorExtensionArray.from_sequence([None, np.ones((2, 3))], dtype=dtype)
 
-    @pytest.mark.skip(reason="Requires TensorExtensionArray")
-    def test_infer_dtype(self):
-        """Skipped until the extension array exists."""
-
-    @pytest.mark.skip(reason="Requires TensorExtensionArray")
-    def test_is_dtype_unboxes_dtype(self):
-        """Skipped until the extension array exists."""
+    @pytest.fixture(params=[True, False])
+    def skipna(self, request):
+        """Provided by pandas' own conftest, so replicated here."""
+        return request.param

--- a/tests/nested_pandas/tensors/test_tensor_dtype.py
+++ b/tests/nested_pandas/tensors/test_tensor_dtype.py
@@ -8,7 +8,6 @@ from pandas.core.dtypes.cast import find_common_type
 from pandas.tests.extension import base
 
 from nested_pandas import TensorDtype
-from nested_pandas.tensors.ext_array import TensorExtensionArray
 
 
 class _NotATensorType(pa.ExtensionType):
@@ -335,24 +334,8 @@ def test_pickle():
 
 
 class TestPandasBaseDtype(base.BaseDtypeTests):
-    """Run pandas' extension dtype conformance suite against TensorDtype."""
+    """Run pandas' extension dtype conformance suite against TensorDtype.
 
-    @pytest.fixture
-    def dtype(self):
-        """The dtype instance the pandas suite is run against."""
-        return TensorDtype(pa.fixed_shape_tensor(pa.float64(), [2, 3]))
-
-    @pytest.fixture
-    def data(self, dtype):
-        """Length-100 array without missing values, as the pandas suite expects."""
-        return TensorExtensionArray.from_stack(np.arange(600.0).reshape(100, 2, 3), dtype=dtype)
-
-    @pytest.fixture
-    def data_missing(self, dtype):
-        """Length-2 array of [missing, valid], as the pandas suite expects."""
-        return TensorExtensionArray.from_sequence([None, np.ones((2, 3))], dtype=dtype)
-
-    @pytest.fixture(params=[True, False])
-    def skipna(self, request):
-        """Provided by pandas' own conftest, so replicated here."""
-        return request.param
+    The ``dtype``, ``data``, ``data_missing`` and ``skipna`` fixtures it uses
+    come from ``conftest.py``.
+    """

--- a/tests/nested_pandas/tensors/test_tensor_ext_array.py
+++ b/tests/nested_pandas/tensors/test_tensor_ext_array.py
@@ -910,8 +910,8 @@ def test_table_from_pandas_and_parquet_round_trip(array_with_missing, dtype, sta
     table = pa.Table.from_pandas(df)
     assert table.schema.field("t").type == dtype.pyarrow_dtype
 
-    # The parquet round trip is only checked without missing values: writing a nullable
-    # fixed_size_list is a pyarrow limitation fixed after 19.0 (see the array docstring)
+    # The parquet round trip is only checked without missing values: a nullable fixed_size_list
+    # does not round-trip parquet before pyarrow 26 (apache/arrow#35692, apache/arrow#35697)
     table = pa.Table.from_pandas(pd.DataFrame({"t": array_with_missing.dropna()}))
     buffer = io.BytesIO()
     pq.write_table(table, buffer)

--- a/tests/nested_pandas/tensors/test_tensor_ext_array.py
+++ b/tests/nested_pandas/tensors/test_tensor_ext_array.py
@@ -1,0 +1,1015 @@
+import io
+import pickle
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from numpy.testing import assert_array_equal
+from pandas.core.arrays import ArrowExtensionArray  # type: ignore[attr-defined]
+from pandas.errors import AbstractMethodError
+from pandas.testing import assert_series_equal
+from tensor_test_utils import TENSOR_SHAPE, tensor, tensor_stack
+
+from nested_pandas import TensorDtype
+from nested_pandas.tensors.ext_array import (
+    TENSOR_FORMATTING_MAX_ELEMENTS,
+    TensorExtensionArray,
+    _format_tensor,
+)
+
+
+@pytest.fixture
+def stack():
+    """A (4, 2, 3) stack of distinct tensors."""
+    return tensor_stack(range(4))
+
+
+@pytest.fixture
+def array(stack, dtype):
+    """A TensorExtensionArray of the four tensors in ``stack``."""
+    return TensorExtensionArray.from_stack(stack, dtype=dtype)
+
+
+@pytest.fixture
+def array_with_missing(stack, dtype):
+    """[stack[0], NA, NA, stack[3]]."""
+    return TensorExtensionArray.from_sequence([stack[0], None, pd.NA, stack[3]], dtype=dtype)
+
+
+def storage_array(stack, mask=None) -> pa.FixedSizeListArray:
+    """The fixed_size_list storage array for a stack, optionally with a row-null mask."""
+    values = pa.array(np.ascontiguousarray(stack).reshape(-1))
+    return pa.FixedSizeListArray.from_arrays(values, int(np.prod(stack.shape[1:])), mask=mask)
+
+
+# Constructor #
+
+
+def test___init___from_extension_array(stack, dtype):
+    """Test constructing from a fixed_shape_tensor extension array infers the dtype."""
+    ext = pa.ExtensionArray.from_storage(dtype.pyarrow_dtype, storage_array(stack))
+    array = TensorExtensionArray(ext)
+    assert array.dtype == dtype
+    assert len(array) == 4
+    assert array.num_chunks == 1
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test___init___from_chunked_array(stack, dtype):
+    """Test constructing from a chunked array keeps the chunks."""
+    ext = pa.ExtensionArray.from_storage(dtype.pyarrow_dtype, storage_array(stack))
+    array = TensorExtensionArray(pa.chunked_array([ext[:1], ext[1:]]))
+    assert array.num_chunks == 2
+    assert len(array) == 4
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test___init___from_storage_with_dtype(stack, dtype):
+    """Test constructing from the fixed_size_list storage array when the dtype is given."""
+    array = TensorExtensionArray(storage_array(stack), dtype=dtype)
+    assert array.dtype == dtype
+    assert isinstance(array.pa_array.type, pa.FixedShapeTensorType)
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test___init___from_storage_without_dtype_raises(stack):
+    """Test that a bare storage array is ambiguous without a dtype."""
+    with pytest.raises(ValueError, match="dtype is required"):
+        TensorExtensionArray(storage_array(stack))
+
+
+def test___init___casts_storage_to_dtype(stack, dtype):
+    """Test that a dtype with a different element type casts the storage."""
+    float32_dtype = TensorDtype(pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE)))
+    array = TensorExtensionArray(storage_array(stack), dtype=float32_dtype)
+    assert array.dtype == float32_dtype
+    assert array.to_stack().dtype == np.float32
+    assert_array_equal(array.to_stack(), stack.astype(np.float32))
+
+    # Also from an extension array of another tensor type
+    array = TensorExtensionArray(TensorExtensionArray.from_stack(stack).pa_array, dtype=float32_dtype)
+    assert array.dtype == float32_dtype
+
+
+def test___init___raises_for_size_mismatch(stack):
+    """Test that a dtype with a different number of elements is rejected with a clear message."""
+    other = TensorDtype(pa.fixed_shape_tensor(pa.float64(), [4]))
+    with pytest.raises(ValueError, match="6 elements to .* which has 4 elements"):
+        TensorExtensionArray(storage_array(stack), dtype=other)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pa.array([1.0, 2.0]),
+        pa.array([[1.0, 2.0]]),
+        pa.array([{"a": [1.0]}]),
+        pa.chunked_array([pa.array([1, 2])]),
+    ],
+)
+def test___init___raises_for_other_arrow_types(values, dtype):
+    """Test that arrays that are neither tensor nor fixed_size_list are rejected."""
+    with pytest.raises(ValueError, match="fixed_shape_tensor or fixed_size_list"):
+        TensorExtensionArray(values, dtype=dtype)
+
+
+def test___init___raises_for_non_arrow(stack):
+    """Test that non-arrow input is rejected."""
+    with pytest.raises(TypeError, match="pyarrow Array or ChunkedArray"):
+        TensorExtensionArray(stack)
+
+
+# from_sequence / from_stack #
+
+
+def test_from_sequence_with_list_of_arrays(stack, dtype):
+    """Test from_sequence with a list of numpy arrays and a dtype."""
+    array = TensorExtensionArray.from_sequence(list(stack), dtype=dtype)
+    assert array.dtype == dtype
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test_from_sequence_infers_dtype(stack):
+    """Test that the dtype is inferred from the first non-missing element."""
+    array = TensorExtensionArray.from_sequence([None, stack[1].astype(np.int32), stack[2].astype(np.int32)])
+    assert array.dtype == TensorDtype(pa.fixed_shape_tensor(pa.int32(), list(TENSOR_SHAPE)))
+    assert array.isna().tolist() == [True, False, False]
+
+
+def test_from_sequence_with_missing(stack, dtype):
+    """Test that None and pd.NA both give missing tensors."""
+    array = TensorExtensionArray.from_sequence([stack[0], None, pd.NA], dtype=dtype)
+    assert array.isna().tolist() == [False, True, True]
+    assert_array_equal(array[0], stack[0])
+
+
+def test_from_sequence_with_lists(dtype):
+    """Test that nested lists are accepted as tensors."""
+    array = TensorExtensionArray.from_sequence([[[0, 1, 2], [3, 4, 5]]], dtype=dtype)
+    assert_array_equal(array[0], np.arange(6.0).reshape(TENSOR_SHAPE))
+
+
+def test_from_sequence_with_pyarrow_array(stack, dtype):
+    """Test from_sequence with an extension array and with a storage array plus dtype."""
+    ext = pa.ExtensionArray.from_storage(dtype.pyarrow_dtype, storage_array(stack))
+    expected = TensorExtensionArray(ext)
+    assert TensorExtensionArray.from_sequence(ext).equals(expected)
+    assert TensorExtensionArray.from_sequence(storage_array(stack), dtype=dtype).equals(expected)
+
+
+def test_from_sequence_with_tensor_scalars(stack, dtype):
+    """Test from_sequence with pyarrow tensor scalars and storage scalars."""
+    ext = pa.ExtensionArray.from_storage(dtype.pyarrow_dtype, storage_array(stack))
+    array = TensorExtensionArray.from_sequence([ext[0], ext[1]], dtype=dtype)
+    assert_array_equal(array.to_stack(), stack[:2])
+    array = TensorExtensionArray.from_sequence([storage_array(stack)[2]], dtype=dtype)
+    assert_array_equal(array[0], stack[2])
+    # The dtype is inferred from a tensor scalar too
+    inferred = TensorExtensionArray.from_sequence([None, ext[1]])
+    assert inferred.dtype == dtype
+    assert_array_equal(inferred[1], stack[1])
+
+
+def test_from_sequence_with_stack(stack, dtype):
+    """Test that an (n, *shape) numpy array is accepted as a stack."""
+    array = TensorExtensionArray.from_sequence(stack)
+    assert array.dtype == dtype
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test_from_sequence_with_self(array):
+    """Test that from_sequence with an existing array returns it, or casts it."""
+    assert TensorExtensionArray.from_sequence(array) is array
+    assert TensorExtensionArray.from_sequence(array, dtype=array.dtype) is array
+    float32_dtype = TensorDtype(pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE)))
+    assert TensorExtensionArray.from_sequence(array, dtype=float32_dtype).dtype == float32_dtype
+
+
+@pytest.mark.parametrize(
+    "dtype_spec",
+    [
+        "tensor[double, (2, 3)]",
+        pa.fixed_shape_tensor(pa.float64(), [2, 3]),
+        pd.ArrowDtype(pa.fixed_shape_tensor(pa.float64(), [2, 3])),
+    ],
+)
+def test_from_sequence_dtype_spellings(stack, dtype, dtype_spec):
+    """Test that the dtype may be given as a string, a pyarrow type or a pd.ArrowDtype."""
+    array = TensorExtensionArray.from_sequence(list(stack), dtype=dtype_spec)
+    assert array.dtype == dtype
+
+
+def test_from_sequence_raises_for_wrong_shape(dtype):
+    """Test that a tensor of the wrong shape is rejected."""
+    with pytest.raises(ValueError, match="Expected a tensor of shape"):
+        TensorExtensionArray.from_sequence([np.zeros((3, 2))], dtype=dtype)
+
+
+def test_from_sequence_raises_for_all_missing_without_dtype():
+    """Test that the dtype cannot be inferred from missing values only."""
+    with pytest.raises(ValueError, match="Cannot infer TensorDtype"):
+        TensorExtensionArray.from_sequence([None, None])
+    assert TensorExtensionArray.from_sequence([None, None], dtype="tensor[double, (2, 3)]").isna().all()
+
+
+def test_from_sequence_raises_for_bad_dtype(stack):
+    """Test that an unrelated dtype is rejected."""
+    with pytest.raises(TypeError, match="Expected TensorDtype"):
+        TensorExtensionArray.from_sequence(list(stack), dtype="int64")
+
+
+def test_from_stack(stack, dtype):
+    """Test from_stack infers the dtype and is zero-copy for C-ordered input."""
+    array = TensorExtensionArray.from_stack(stack)
+    assert array.dtype == dtype
+    assert np.shares_memory(array.to_stack(), stack)
+
+
+def test_from_stack_with_dtype(stack):
+    """Test from_stack casts to the given element type."""
+    float32_dtype = TensorDtype(pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE)))
+    array = TensorExtensionArray.from_stack(stack, dtype=float32_dtype)
+    assert array.dtype == float32_dtype
+    assert_array_equal(array.to_stack(), stack.astype(np.float32))
+
+
+def test_from_stack_non_contiguous(stack):
+    """Test that a non C-contiguous stack is copied into C order rather than mis-read."""
+    transposed = np.ascontiguousarray(stack.transpose(0, 2, 1)).transpose(0, 2, 1)
+    assert not transposed.flags.c_contiguous
+    array = TensorExtensionArray.from_stack(transposed)
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test_from_stack_raises(stack, dtype):
+    """Test from_stack rejects too few dimensions and a shape mismatch."""
+    with pytest.raises(ValueError, match="at least two dimensions"):
+        TensorExtensionArray.from_stack(np.arange(6.0))
+    with pytest.raises(ValueError, match="Expected a stack of tensors of shape"):
+        TensorExtensionArray.from_stack(stack.reshape(4, 3, 2), dtype=dtype)
+
+
+# to_stack #
+
+
+def test_to_stack_zero_copy(array, stack):
+    """Test that to_stack is a read-only view for a single chunk without missing values."""
+    result = array.to_stack()
+    assert_array_equal(result, stack)
+    assert np.shares_memory(result, stack)
+    assert not result.flags.writeable
+
+
+def test_to_stack_multiple_chunks(array, stack):
+    """Test that to_stack combines chunks."""
+    chunked = TensorExtensionArray._concat_same_type([array[:2], array[2:]])
+    assert chunked.num_chunks == 2
+    assert_array_equal(chunked.to_stack(), stack)
+
+
+def test_to_stack_with_missing(array_with_missing, stack):
+    """Test that missing tensors are filled with na_value, widening the dtype if needed."""
+    result = array_with_missing.to_stack()
+    assert result.dtype == np.float64
+    assert np.isnan(result[1]).all() and np.isnan(result[2]).all()
+    assert_array_equal(result[0], stack[0])
+    assert_array_equal(result[3], stack[3])
+    assert_array_equal(array_with_missing.to_stack(na_value=-1.0)[1], np.full(TENSOR_SHAPE, -1.0))
+
+
+def test_to_stack_int_widening():
+    """Test that integer tensors widen to float for a nan fill, and keep their dtype otherwise."""
+    array = TensorExtensionArray.from_sequence([np.ones(TENSOR_SHAPE, dtype=np.int32), None])
+    assert array.to_stack().dtype == np.float64
+    assert array.to_stack(na_value=0).dtype == np.int32
+    no_missing = TensorExtensionArray.from_sequence([np.ones(TENSOR_SHAPE, dtype=np.int32)])
+    assert no_missing.to_stack().dtype == np.int32
+
+
+def test_to_stack_empty(array):
+    """Test to_stack for an empty array."""
+    result = array[:0].to_stack()
+    assert result.shape == (0, *TENSOR_SHAPE)
+    assert result.dtype == np.float64
+
+
+def test_to_stack_sliced(array, stack):
+    """Test that a sliced array, whose arrow buffers have an offset, gives the right rows."""
+    assert_array_equal(array[1:3].to_stack(), stack[1:3])
+    assert_array_equal(array[1:][1:].to_stack(), stack[2:])
+
+
+# Element-level nulls, which only arrow input can produce #
+
+
+@pytest.fixture
+def element_null_array(stack, dtype):
+    """stack with element [0, 0, 1] null and row 1 null."""
+    values = pa.array(np.ascontiguousarray(stack).reshape(-1).tolist(), type=pa.float64())
+    values = pa.compute.if_else(pa.array(np.arange(len(values)) == 1), None, values)
+    storage = pa.FixedSizeListArray.from_arrays(values, 6, mask=pa.array([False, True, False, False]))
+    return TensorExtensionArray(pa.ExtensionArray.from_storage(dtype.pyarrow_dtype, storage), dtype=dtype)
+
+
+def test_element_null_is_not_row_null(element_null_array):
+    """Test that a missing element does not make the tensor missing."""
+    assert element_null_array.isna().tolist() == [False, True, False, False]
+
+
+def test_element_null_becomes_nan(element_null_array, stack):
+    """Test that a missing element reads as NaN through every path, as numpy does."""
+    assert np.isnan(element_null_array[0][0, 1])
+    assert np.isnan(element_null_array.to_stack()[0, 0, 1])
+    assert np.isnan(element_null_array.to_numpy()[0][0, 1])
+    assert_array_equal(element_null_array[2], stack[2])
+    assert_array_equal(element_null_array[1:][1:].to_stack()[0], stack[2])
+    # nan != nan
+    assert (element_null_array == element_null_array).tolist() == [False, pd.NA, True, True]
+
+
+def test_element_null_int_upcast():
+    """Test that integer tensors with a missing element are read as float."""
+    dtype = TensorDtype(pa.fixed_shape_tensor(pa.int64(), [2, 3]))
+    values = pa.array([0, None, 2, 3, 4, 5], type=pa.int64())
+    storage = pa.FixedSizeListArray.from_arrays(values, 6)
+    array = TensorExtensionArray(pa.ExtensionArray.from_storage(dtype.pyarrow_dtype, storage), dtype=dtype)
+    assert array.to_stack().dtype == np.float64
+    assert array[0].dtype == np.float64
+    assert np.isnan(array[0][0, 1])
+
+
+# dtype and Series construction #
+
+
+def test_ext_array_dtype(array, dtype):
+    """Test the dtype attribute."""
+    assert array.dtype == dtype
+    assert isinstance(array.dtype, TensorDtype)
+
+
+def test_series_dtype(array, dtype):
+    """Test that a Series holding the array has the tensor dtype."""
+    series = pd.Series(array)
+    assert series.dtype == dtype
+    assert isinstance(series.array, TensorExtensionArray)
+    assert series.array.equals(array)
+
+
+def test_series_built_with_dtype(stack, dtype):
+    """Test building a Series from tensors with the dtype given as an object and as a string."""
+    series = pd.Series(list(stack), dtype=dtype)
+    assert series.dtype == dtype
+    assert_array_equal(series.iloc[2], stack[2])
+    series = pd.Series([stack[0], None], dtype="tensor[double, (2, 3)]")
+    assert series.dtype == dtype
+    assert series.isna().tolist() == [False, True]
+
+
+def test_series_built_raises(dtype):
+    """Test that a Series cannot be built from tensors of the wrong shape."""
+    with pytest.raises(ValueError):
+        pd.Series([np.zeros((3, 2))], dtype=dtype)
+
+
+# __getitem__ #
+
+
+def test___getitem___with_integer(array, stack):
+    """Test scalar access gives a read-only view of the right tensor, negative indices included."""
+    result = array[1]
+    assert isinstance(result, np.ndarray)
+    assert result.shape == TENSOR_SHAPE
+    assert_array_equal(result, stack[1])
+    assert np.shares_memory(result, stack)
+    assert not result.flags.writeable
+    assert_array_equal(array[-1], stack[-1])
+
+
+def test___getitem___with_integer_out_of_bounds(array):
+    """Test that an out of bounds scalar index raises IndexError."""
+    with pytest.raises(IndexError):
+        array[4]
+
+
+def test___getitem___missing(array_with_missing):
+    """Test that a missing tensor is returned as pd.NA."""
+    assert array_with_missing[1] is pd.NA
+
+
+def test___getitem___with_slice(array, stack):
+    """Test slicing returns a new array."""
+    result = array[1:3]
+    assert isinstance(result, TensorExtensionArray)
+    assert len(result) == 2
+    assert_array_equal(result.to_stack(), stack[1:3])
+    assert_array_equal(array[::2].to_stack(), stack[::2])
+
+
+def test___getitem___with_integer_ndarray(array, stack):
+    """Test indexing with integer arrays and lists."""
+    assert_array_equal(array[np.array([3, 0])].to_stack(), stack[[3, 0]])
+    assert_array_equal(array[[3, 0, 0]].to_stack(), stack[[3, 0, 0]])
+    assert_array_equal(array[np.array([1], dtype=np.uint8)].to_stack(), stack[[1]])
+
+
+def test___getitem___with_boolean_ndarray(array, stack):
+    """Test indexing with a boolean mask."""
+    mask = np.array([True, False, True, False])
+    assert_array_equal(array[mask].to_stack(), stack[mask])
+    assert_array_equal(array[mask.tolist()].to_stack(), stack[mask])
+
+
+def test___getitem___with_empty_ndarray(array):
+    """Test indexing with an empty index array."""
+    result = array[np.array([], dtype=int)]
+    assert len(result) == 0
+    assert result.dtype == array.dtype
+
+
+def test___getitem___raises_for_invalid_ndarray_dtype(array):
+    """Test that a float index array is rejected."""
+    with pytest.raises(IndexError):
+        array[np.array([0.5, 1.5])]
+
+
+def test___getitem___with_ellipsis(array):
+    """Test that Ellipsis returns the whole array."""
+    assert array[...].equals(array)
+
+
+def test___getitem___with_single_element_tuple(array, stack):
+    """Test that a single-element tuple is unpacked."""
+    assert_array_equal(array[(1,)], stack[1])
+    assert_array_equal(array[(slice(1, 3),)].to_stack(), stack[1:3])
+
+
+def test_series___getitem__(array, stack):
+    """Test the Series indexers over a tensor column."""
+    series = pd.Series(array, index=list("abcd"))
+    assert_array_equal(series["b"], stack[1])
+    assert_array_equal(series.iloc[1], stack[1])
+    assert_array_equal(series.iloc[1:3].array.to_stack(), stack[1:3])
+    assert_array_equal(series.iloc[[3, 0]].array.to_stack(), stack[[3, 0]])
+    assert_array_equal(series[np.array([True, False, True, False])].array.to_stack(), stack[[0, 2]])
+    assert_array_equal(series.loc[["d", "a"]].array.to_stack(), stack[[3, 0]])
+
+
+# __setitem__ #
+
+
+def test___setitem___single_tensor(array, stack):
+    """Test assigning a single tensor to one position."""
+    new = np.full(TENSOR_SHAPE, -1.0)
+    array[1] = new
+    assert_array_equal(array[1], new)
+    assert_array_equal(array[0], stack[0])
+    assert_array_equal(array[2], stack[2])
+
+
+def test___setitem___with_negative_index(array, stack):
+    """Test assigning with a negative index."""
+    array[-1] = np.zeros(TENSOR_SHAPE)
+    assert_array_equal(array[3], np.zeros(TENSOR_SHAPE))
+    assert_array_equal(array[2], stack[2])
+
+
+def test___setitem___with_tuple(array):
+    """Test assigning with a single-element tuple key."""
+    array[(1,)] = np.zeros(TENSOR_SHAPE)
+    assert_array_equal(array[1], np.zeros(TENSOR_SHAPE))
+
+
+def test___setitem___with_empty_key(array, stack):
+    """Test that assigning to no positions is a no-op."""
+    array[np.array([], dtype=int)] = np.zeros(TENSOR_SHAPE)
+    assert_array_equal(array.to_stack(), stack)
+
+
+def test___setitem___single_tensor_to_all_rows(array):
+    """Test broadcasting one tensor to every row."""
+    array[:] = np.ones(TENSOR_SHAPE)
+    assert_array_equal(array.to_stack(), np.ones((4, *TENSOR_SHAPE)))
+
+
+def test___setitem___list_of_tensors(array, stack):
+    """Test assigning a sequence of tensors to integer positions, out of order."""
+    array[[3, 0]] = [np.zeros(TENSOR_SHAPE), np.ones(TENSOR_SHAPE)]
+    assert_array_equal(array[3], np.zeros(TENSOR_SHAPE))
+    assert_array_equal(array[0], np.ones(TENSOR_SHAPE))
+    assert_array_equal(array[1], stack[1])
+
+
+def test___setitem___with_duplicate_integer_keys(array):
+    """Test that duplicate integer keys are handled like numpy: the value for each unique key is used."""
+    array[[1, 1, 2]] = [np.zeros(TENSOR_SHAPE), np.zeros(TENSOR_SHAPE), np.ones(TENSOR_SHAPE)]
+    assert_array_equal(array[1], np.zeros(TENSOR_SHAPE))
+    assert_array_equal(array[2], np.ones(TENSOR_SHAPE))
+
+
+def test___setitem___with_boolean_mask(array, stack):
+    """Test assigning with a boolean mask, with a single tensor and with a sequence."""
+    mask = np.array([True, False, False, True])
+    array[mask] = np.zeros(TENSOR_SHAPE)
+    assert_array_equal(array.to_stack()[mask], np.zeros((2, *TENSOR_SHAPE)))
+    array[mask] = stack[[3, 0]]
+    assert_array_equal(array[0], stack[3])
+    assert_array_equal(array[3], stack[0])
+
+
+def test___setitem___other_ext_array(array, stack):
+    """Test assigning from another TensorExtensionArray, including one of another element type."""
+    other = TensorExtensionArray.from_stack(stack[[3, 2]])
+    array[[0, 1]] = other
+    assert_array_equal(array.to_stack(), stack[[3, 2, 2, 3]])
+    float32 = TensorExtensionArray.from_stack(np.ones((1, *TENSOR_SHAPE), dtype=np.float32))
+    array[[0]] = float32
+    assert array.dtype.value_type == pa.float64()
+    assert_array_equal(array[0], np.ones(TENSOR_SHAPE))
+
+
+def test___setitem___series_of_tensors(array, stack):
+    """Test assigning from a Series of tensors."""
+    array[[0, 1]] = pd.Series([stack[3], stack[2]], dtype=array.dtype)
+    assert_array_equal(array.to_stack(), stack[[3, 2, 2, 3]])
+
+
+def test___setitem___missing(array):
+    """Test assigning None and pd.NA makes tensors missing."""
+    array[0] = None
+    array[np.array([False, False, True, False])] = pd.NA
+    assert array.isna().tolist() == [True, False, True, False]
+    assert array[0] is pd.NA
+
+
+def test___setitem___raises_for_wrong_shape(array):
+    """Test that a tensor of the wrong shape cannot be assigned."""
+    with pytest.raises(ValueError, match="Expected a tensor of shape"):
+        array[0] = np.zeros((3, 2))
+
+
+@pytest.mark.parametrize("key", [[4], [0, 4], [-5]])
+def test___setitem___raises_for_out_of_bounds_key(array, key):
+    """Test that integer keys outside the array raise IndexError."""
+    with pytest.raises(IndexError):
+        array[key] = np.zeros(TENSOR_SHAPE)
+
+
+def test___setitem___raises_for_length_mismatch(array):
+    """Test that a sequence of the wrong length cannot be assigned."""
+    with pytest.raises(ValueError, match="Cannot set 2 elements from a sequence of length 3"):
+        array[[0, 1]] = [np.zeros(TENSOR_SHAPE)] * 3
+
+
+def test___setitem___does_not_modify_other_views(array, stack):
+    """Test that arrow immutability keeps copies independent."""
+    copy = array.copy()
+    array[0] = np.zeros(TENSOR_SHAPE)
+    assert_array_equal(copy[0], stack[0])
+
+
+def test_series___setitem__(array, stack):
+    """Test assignment through a Series.
+
+    A single tensor can be assigned to one label with ``series[label] = tensor``, and sequences
+    of tensors, TensorExtensionArrays and missing values assign anywhere. Broadcasting one
+    tensor to several positions, and ``loc``/``iloc`` with a single tensor, are not supported
+    because pandas inspects the ndarray itself and treats it as a sequence; use ``series.array``
+    for those.
+    """
+    series = pd.Series(array.copy())
+    series[0] = np.ones(TENSOR_SHAPE)
+    series.iloc[[1]] = TensorExtensionArray.from_stack(np.zeros((1, *TENSOR_SHAPE)))
+    series[[2, 3]] = [stack[3], stack[2]]
+    assert_array_equal(series.iloc[0], np.ones(TENSOR_SHAPE))
+    assert_array_equal(series.iloc[1], np.zeros(TENSOR_SHAPE))
+    assert_array_equal(series.iloc[2], stack[3])
+    series[series.index == 3] = None
+    series.array[[0, 2]] = np.full(TENSOR_SHAPE, 7.0)
+    assert series.isna().tolist() == [False, False, False, True]
+    assert_array_equal(series.iloc[2], np.full(TENSOR_SHAPE, 7.0))
+    # The original array is untouched
+    assert_array_equal(array.to_stack(), stack)
+
+
+# isna #
+
+
+def test_isna_when_none_na(array):
+    """Test isna and _hasna with no missing values."""
+    assert not array.isna().any()
+    assert not array._hasna
+
+
+def test_isna_when_all_na(dtype):
+    """Test isna and _hasna when everything is missing."""
+    array = TensorExtensionArray.from_sequence([None, None], dtype=dtype)
+    assert array.isna().all()
+    assert array._hasna
+
+
+def test_isna_when_some_na(array_with_missing):
+    """Test isna and _hasna with some missing values."""
+    assert array_with_missing.isna().tolist() == [False, True, True, False]
+    assert array_with_missing._hasna
+
+
+# take #
+
+
+def test_take(array, stack):
+    """Test take with positive and negative indices."""
+    assert_array_equal(array.take([3, 0, 0]).to_stack(), stack[[3, 0, 0]])
+    assert_array_equal(array.take([-1, -4]).to_stack(), stack[[3, 0]])
+    assert_array_equal(array.take(np.array([1, 2])).to_stack(), stack[1:3])
+    assert len(array.take([])) == 0
+
+
+def test_take_allow_fill(array, stack):
+    """Test take with allow_fill: -1 gives missing, or the fill tensor."""
+    result = array.take([0, -1, 3], allow_fill=True)
+    assert result.isna().tolist() == [False, True, False]
+    assert_array_equal(result[2], stack[3])
+    result = array.take([0, -1], allow_fill=True, fill_value=np.zeros(TENSOR_SHAPE))
+    assert not result.isna().any()
+    assert_array_equal(result[1], np.zeros(TENSOR_SHAPE))
+    # No fill needed
+    assert_array_equal(array.take([1, 2], allow_fill=True).to_stack(), stack[1:3])
+
+
+def test_take_allow_fill_raises_below_minus_one(array):
+    """Test that with allow_fill only -1 is a valid negative index."""
+    with pytest.raises(ValueError):
+        array.take([0, -2], allow_fill=True)
+
+
+def test_take_raises_for_empty_array_and_non_empty_index(array):
+    """Test that taking from an empty array raises."""
+    with pytest.raises(IndexError, match="non-empty take from the empty array"):
+        array[:0].take([0])
+
+
+@pytest.mark.parametrize("indices", [[4], [0, 4], [-5], [0, -5]])
+def test_take_raises_for_out_of_bounds_index(array, indices):
+    """Test that out of bounds indices, above or below, raise our IndexError rather than pyarrow's."""
+    with pytest.raises(IndexError, match="out of bounds value in 'indices'"):
+        array.take(indices)
+
+
+# Misc ExtensionArray API #
+
+
+def test_copy(array):
+    """Test that copy gives an equal but independent array."""
+    copy = array.copy()
+    assert copy is not array
+    assert copy.equals(array)
+    copy[0] = None
+    assert not array.isna().any()
+
+
+def test__formatter_unboxed(array):
+    """Test the unboxed formatter is repr."""
+    assert array._formatter(boxed=False) is repr
+
+
+def test__formatter_boxed(array, stack):
+    """Test the boxed formatter shows small tensors in full and larger ones as a descriptor."""
+    formatter = array._formatter(boxed=True)
+    assert formatter(array[0]) == str(stack[0].tolist())
+    assert formatter(pd.NA) == "<NA>"
+    assert formatter(None) == "<NA>"
+    big = np.zeros((8, 8), dtype=np.float32)
+    assert big.size > TENSOR_FORMATTING_MAX_ELEMENTS
+    assert formatter(big) == "[8×8] float32"
+    assert _format_tensor(np.zeros(5, dtype=np.int16)) == "[0, 0, 0, 0, 0]"
+    assert _format_tensor(np.zeros((3, 4, 5))) == "[3×4×5] float64"
+
+
+def test_series_repr(array_with_missing, stack):
+    """Test the text repr of a Series and a DataFrame with a tensor column."""
+    text = repr(pd.Series(array_with_missing, name="t"))
+    assert str(stack[0].tolist()) in text
+    assert "<NA>" in text
+    assert "tensor[double, (2, 3)]" in text
+    big = TensorExtensionArray.from_stack(np.zeros((2, 8, 8)))
+    assert "[8×8] float64" in repr(pd.DataFrame({"a": [1, 2], "t": big}))
+
+
+def test_nbytes(array, stack):
+    """Test nbytes accounts for the tensor data."""
+    assert array.nbytes >= stack.nbytes
+
+
+def test_pickability(array_with_missing):
+    """Test pickling of the array and of a Series holding it."""
+    assert pickle.loads(pickle.dumps(array_with_missing)).equals(array_with_missing)
+    series = pd.Series(array_with_missing, name="t")
+    assert_series_equal(pickle.loads(pickle.dumps(series)), series)
+
+
+def test_pickle_slice_is_compact(dtype):
+    """Test that pickling a slice does not serialize the whole parent buffer."""
+    big = TensorExtensionArray.from_stack(np.zeros((100_000, 8, 8)), dtype=None)
+    pickled = pickle.dumps(big[:10])
+    assert len(pickled) < 100_000
+    assert pickle.loads(pickled).equals(big[:10])
+
+
+def test_pickle_edge_cases(array):
+    """Test pickling empty and multi-chunk arrays."""
+    assert pickle.loads(pickle.dumps(array[:0])).equals(array[:0])
+    chunked = TensorExtensionArray._concat_same_type([array[:2], array[2:]])
+    assert pickle.loads(pickle.dumps(chunked)).equals(chunked)
+
+
+def test__concat_same_type(array, array_with_missing, stack):
+    """Test concatenation keeps the chunks and the dtype."""
+    result = TensorExtensionArray._concat_same_type([array, array_with_missing])
+    assert len(result) == 8
+    assert result.num_chunks == 2
+    assert result.dtype == array.dtype
+    assert result.isna().tolist() == [False] * 4 + [False, True, True, False]
+    assert_array_equal(result[:4].to_stack(), stack)
+
+
+def test_equals(array, array_with_missing):
+    """Test equals for equal, copied and different arrays."""
+    assert array.equals(array)
+    assert array.equals(array.copy())
+    assert array.equals(TensorExtensionArray._concat_same_type([array[:2], array[2:]]))
+    assert not array.equals(array_with_missing)
+    assert not array.equals(array[:3])
+    float32_dtype = TensorDtype(pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE)))
+    assert not array.equals(array.astype(float32_dtype))
+
+
+def test_equals_when_other_is_different_type(array):
+    """Test equals with something that is not a TensorExtensionArray."""
+    assert not array.equals(array.to_stack())
+    assert not array.equals(pd.Series(array))
+    assert not array.equals(None)
+
+
+def test_dropna(array_with_missing, stack):
+    """Test dropna removes missing tensors."""
+    result = array_with_missing.dropna()
+    assert len(result) == 2
+    assert_array_equal(result.to_stack(), stack[[0, 3]])
+
+
+def test___iter__(array_with_missing, stack):
+    """Test iteration yields tensors and pd.NA."""
+    items = list(array_with_missing)
+    assert [type(item).__name__ for item in items] == ["ndarray", "NAType", "NAType", "ndarray"]
+    assert_array_equal(items[3], stack[3])
+
+
+def test_to_numpy(array_with_missing, stack):
+    """Test to_numpy gives an object array of tensors with na_value for missing ones."""
+    result = array_with_missing.to_numpy()
+    assert result.dtype == object
+    assert result.shape == (4,)
+    assert_array_equal(result[0], stack[0])
+    assert result[1] is pd.NA
+    assert array_with_missing.to_numpy(na_value=None)[1] is None
+    assert not result[0].flags.writeable
+    assert array_with_missing.to_numpy(copy=True)[0].flags.writeable
+
+
+def test___array__(array_with_missing, stack):
+    """Test numpy conversion gives the object array, also through a Series."""
+    result = np.asarray(array_with_missing)
+    assert result.dtype == object and result.shape == (4,)
+    assert_array_equal(result[3], stack[3])
+    assert np.asarray(pd.Series(array_with_missing)).shape == (4,)
+
+
+def test_num_chunks_and_pa_array(array):
+    """Test the pyarrow accessors."""
+    assert array.num_chunks == 1
+    assert isinstance(array.pa_array, pa.ChunkedArray)
+    assert isinstance(array.pa_array.type, pa.FixedShapeTensorType)
+    assert array.storage.type == array.dtype.storage_type
+    chunked = TensorExtensionArray._concat_same_type([array[:1], array[1:]])
+    assert chunked.num_chunks == 2
+    assert chunked.storage.num_chunks == 2
+
+
+# astype #
+
+
+def test_astype_same_dtype(array):
+    """Test astype to the same dtype copies or returns self."""
+    assert array.astype(array.dtype, copy=False) is array
+    result = array.astype(array.dtype)
+    assert result is not array
+    assert result.equals(array)
+
+
+def test_astype_other_tensor_dtype(array, stack):
+    """Test astype to another element type and to another shape with the same size."""
+    float32_dtype = TensorDtype(pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE)))
+    result = array.astype(float32_dtype)
+    assert result.dtype == float32_dtype
+    assert_array_equal(result.to_stack(), stack.astype(np.float32))
+    reshaped = array.astype(TensorDtype(pa.fixed_shape_tensor(pa.float64(), [3, 2])))
+    assert reshaped[0].shape == (3, 2)
+    assert_array_equal(reshaped[0], stack[0].reshape(3, 2))
+    assert array.astype("tensor[float, (2, 3)]").dtype == float32_dtype
+
+
+def test_astype_raises_for_size_mismatch(array):
+    """Test astype to a tensor dtype with a different number of elements raises."""
+    with pytest.raises(ValueError, match="6 elements"):
+        array.astype(TensorDtype(pa.fixed_shape_tensor(pa.float64(), [4])))
+
+
+def test_astype_to_pandas_arrow_dtype(array, dtype, stack):
+    """Test astype to pd.ArrowDtype of the tensor type and of list types."""
+    result = array.astype(dtype.to_pandas_arrow_dtype())
+    assert isinstance(result, ArrowExtensionArray)
+    assert result.dtype == dtype.to_pandas_arrow_dtype()
+    result = array.astype(dtype.to_pandas_arrow_dtype(storage=True))
+    assert result.dtype == pd.ArrowDtype(pa.list_(pa.float64(), 6))
+    assert result[0] == stack[0].reshape(-1).tolist()
+    result = array.astype(pd.ArrowDtype(pa.list_(pa.float32())))
+    assert result.dtype == pd.ArrowDtype(pa.list_(pa.float32()))
+
+
+def test_astype_to_object(array_with_missing, stack):
+    """Test astype to object gives the object array."""
+    result = array_with_missing.astype(object)
+    assert result.dtype == object
+    assert_array_equal(result[0], stack[0])
+    assert result[1] is pd.NA
+
+
+# Arrow interop #
+
+
+def test___arrow_array__(array, dtype):
+    """Test conversion to arrow gives the extension array by default."""
+    result = pa.array(array)
+    assert result.type == dtype.pyarrow_dtype
+    assert isinstance(array.__arrow_array__(), pa.ChunkedArray)
+    assert pa.table({"t": array}).schema.field("t").type == dtype.pyarrow_dtype
+
+
+def test___arrow_array___with_type(array, stack):
+    """Test conversion to arrow with an explicit type."""
+    float32_type = pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE))
+    assert array.__arrow_array__(type=float32_type).type == float32_type
+    # pa.array() unwraps an extension type itself and asks for the storage type instead
+    assert pa.array(array, type=float32_type).type == float32_type.storage_type
+    as_list = pa.array(array, type=pa.list_(pa.float64(), 6))
+    assert as_list.type == pa.list_(pa.float64(), 6)
+    assert as_list[0].as_py() == stack[0].reshape(-1).tolist()
+    assert pa.array(array, type=pa.large_list(pa.float64())).type == pa.large_list(pa.float64())
+
+
+def test_table_from_pandas_and_parquet_round_trip(array_with_missing, dtype, stack):
+    """Test that the tensor type survives pa.Table.from_pandas and a parquet round trip."""
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "t": array_with_missing})
+    table = pa.Table.from_pandas(df)
+    assert table.schema.field("t").type == dtype.pyarrow_dtype
+
+    # The parquet round trip is only checked without missing values: writing a nullable
+    # fixed_size_list is a pyarrow limitation fixed after 19.0 (see the array docstring)
+    table = pa.Table.from_pandas(pd.DataFrame({"t": array_with_missing.dropna()}))
+    buffer = io.BytesIO()
+    pq.write_table(table, buffer)
+    buffer.seek(0)
+    read = pq.read_table(buffer)
+    assert read.schema.field("t").type == dtype.pyarrow_dtype
+    back = TensorExtensionArray(read.column("t"))
+    assert_array_equal(back.to_stack(), stack[[0, 3]])
+    # And via __from_arrow__ with a types_mapper
+    df_back = read.to_pandas(types_mapper=lambda t: dtype if isinstance(t, pa.FixedShapeTensorType) else None)
+    assert df_back["t"].dtype == dtype
+
+
+def test_from_arrow_ext_array_and_back(array, dtype):
+    """Test conversion to and from pandas' ArrowExtensionArray, of the tensor and the storage type."""
+    as_tensor = array.to_arrow_ext_array()
+    assert as_tensor.dtype == dtype.to_pandas_arrow_dtype()
+    assert TensorExtensionArray.from_arrow_ext_array(as_tensor).equals(array)
+    as_storage = array.to_arrow_ext_array(storage=True)
+    assert as_storage.dtype == dtype.to_pandas_arrow_dtype(storage=True)
+    assert TensorExtensionArray.from_arrow_ext_array(as_storage, dtype=dtype).equals(array)
+
+
+def test_dtype___from_arrow__(array, dtype, stack):
+    """Test the dtype's __from_arrow__ hook with extension and storage arrays."""
+    assert dtype.__from_arrow__(array.pa_array).equals(array)
+    assert_array_equal(dtype.__from_arrow__(storage_array(stack)).to_stack(), stack)
+
+
+# __eq__ #
+
+
+def test___eq___same_values(array, stack):
+    """Test elementwise equality with another array, a single tensor, a list and a stack."""
+    result = array == array.copy()
+    assert isinstance(result, pd.arrays.BooleanArray)
+    assert result.all() and not result.isna().any()
+    assert (array == array.take([1, 2, 3, 0])).tolist() == [False] * 4
+    assert (array == stack[0]).tolist() == [True, False, False, False]
+    assert (array == [stack[0], stack[1], stack[0], stack[3]]).tolist() == [True, True, False, True]
+    assert (array == array.to_stack()).all()
+    assert (array != array.copy()).sum() == 0
+
+
+def test___eq___with_missing(array, array_with_missing):
+    """Test that missing values give NA."""
+    result = array == array_with_missing
+    assert result.isna().tolist() == [False, True, True, False]
+    assert bool(result[0]) and bool(result[3])
+    assert (array == pd.NA).isna().all()
+    assert (array == None).isna().all()  # noqa: E711
+
+
+def test___eq___incomparable(array):
+    """Test that anything not interpretable as tensors of this dtype compares False."""
+    assert (array == 5).tolist() == [False] * 4
+    assert (array == "abc").tolist() == [False] * 4
+    assert (array == np.zeros((3, 2))).tolist() == [False] * 4
+    float32_dtype = TensorDtype(pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE)))
+    assert (array == array.astype(float32_dtype)).tolist() == [False] * 4
+
+
+def test___eq___raises_for_length_mismatch(array):
+    """Test that arrays of different lengths cannot be compared."""
+    with pytest.raises(ValueError, match="Lengths must match"):
+        array == array[:2]  # noqa: B015
+
+
+def test___eq___nan(dtype):
+    """Test nan != nan, as in numpy."""
+    array = TensorExtensionArray.from_sequence([np.full(TENSOR_SHAPE, np.nan)], dtype=dtype)
+    assert (array == array).tolist() == [False]
+    assert (array[:0] == array[:0]).tolist() == []
+
+
+def test_series___eq__(array, array_with_missing, stack):
+    """Test comparison through pandas Series."""
+    result = pd.Series(array) == pd.Series(array_with_missing)
+    assert str(result.dtype) == "boolean"
+    assert result.isna().tolist() == [False, True, True, False]
+    others = [stack[0], stack[1], stack[0], stack[3]]
+    assert (pd.Series(array) == others).tolist() == [True, True, False, True]
+    df = pd.DataFrame({"t": array})
+    assert (df["t"] != df["t"]).sum() == 0
+    # With a Series on the right, the array defers to pandas, which dispatches back with the values
+    result = array == pd.Series(array_with_missing)
+    assert isinstance(result, pd.Series)
+    assert result.isna().tolist() == [False, True, True, False]
+
+
+# Pandas integration #
+
+
+def test_dataframe_operations(array, stack):
+    """Test filtering, concat and column access on a DataFrame with a tensor column."""
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "t": array})
+    assert df["t"].dtype == array.dtype
+    sub = df[df["a"] > 2]
+    assert len(sub) == 2
+    assert_array_equal(sub["t"].iloc[0], stack[2])
+    both = pd.concat([df, df], ignore_index=True)
+    assert both["t"].dtype == array.dtype
+    assert len(both) == 8
+    assert isinstance(df.to_html(), str)
+
+
+def test_series_apply_udf_argument(array, stack):
+    """Test that a user function applied to a tensor Series receives the tensors."""
+    result = pd.Series(array).apply(np.sum)
+    assert_array_equal(result.to_numpy(), stack.sum(axis=(1, 2)))
+    result = pd.Series(array).map(lambda t: t.shape)
+    assert result.tolist() == [TENSOR_SHAPE] * 4
+
+
+def test_series_interpolate_not_implemented(array_with_missing):
+    """Test that interpolation is not supported, as for nested columns."""
+    with pytest.raises(NotImplementedError):
+        pd.Series(array_with_missing).interpolate()
+
+
+def test__from_sequence_of_strings_not_implemented(dtype):
+    """Test that constructing from strings is not supported."""
+    with pytest.raises(AbstractMethodError):
+        TensorExtensionArray._from_sequence_of_strings(["[1, 2]"], dtype=dtype)
+
+
+def test__from_factorized_not_implemented(array):
+    """Test that factorization is not supported, since tensors are not hashable."""
+    with pytest.raises(AbstractMethodError):
+        TensorExtensionArray._from_factorized(array.to_numpy(), array)
+
+
+def test_zero_copy_helpers(stack):
+    """Test the conftest helpers give distinct tensors of the expected shape."""
+    assert tensor(0).shape == TENSOR_SHAPE
+    assert not np.array_equal(stack[0], stack[1])

--- a/tests/nested_pandas/tensors/test_tensor_ext_array.py
+++ b/tests/nested_pandas/tensors/test_tensor_ext_array.py
@@ -8,9 +8,8 @@ import pyarrow.parquet as pq
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.core.arrays import ArrowExtensionArray  # type: ignore[attr-defined]
-from pandas.errors import AbstractMethodError
 from pandas.testing import assert_series_equal
-from tensor_test_utils import TENSOR_SHAPE, tensor, tensor_stack
+from tensor_test_utils import TENSOR_SHAPE, tensor_stack
 
 from nested_pandas import TensorDtype
 from nested_pandas.tensors.ext_array import (
@@ -55,6 +54,26 @@ def test___init___from_extension_array(stack, dtype):
     assert len(array) == 4
     assert array.num_chunks == 1
     assert_array_equal(array.to_stack(), stack)
+
+
+def test___init___drops_identity_permutation(stack, dtype):
+    """Test that an identity permutation is normalized away from the stored array as from the dtype.
+
+    ``pa.FixedShapeTensorArray.from_numpy_ndarray()`` always sets one, and pyarrow compares the
+    types with and without it equal, so the array must check for it explicitly.
+    """
+    ext = pa.FixedShapeTensorArray.from_numpy_ndarray(stack)
+    assert ext.type.permutation is not None
+    array = TensorExtensionArray(ext)
+    assert array.dtype == dtype
+    assert array.pa_array.type.permutation is None
+    assert array.pa_array.type == dtype.pyarrow_dtype
+    assert pa.array(array).type.permutation is None
+    assert_array_equal(array.to_stack(), stack)
+
+    # Also when the dtype is given explicitly
+    array = TensorExtensionArray(ext, dtype=dtype)
+    assert array.pa_array.type.permutation is None
 
 
 def test___init___from_chunked_array(stack, dtype):
@@ -481,10 +500,28 @@ def test___setitem___with_tuple(array):
     assert_array_equal(array[1], np.zeros(TENSOR_SHAPE))
 
 
-def test___setitem___with_empty_key(array, stack):
-    """Test that assigning to no positions is a no-op."""
-    array[np.array([], dtype=int)] = np.zeros(TENSOR_SHAPE)
+@pytest.mark.parametrize(
+    "key",
+    [np.array([], dtype=int), [], slice(3, 1), slice(0, 0), np.zeros(4, dtype=bool)],
+    ids=["empty_int_array", "empty_list", "empty_slice", "zero_slice", "all_false_mask"],
+)
+@pytest.mark.parametrize("value_kind", ["tensor", "missing", "empty_sequence"])
+def test___setitem___with_empty_key(array, stack, key, value_kind):
+    """Test that assigning to no positions is a no-op, for a tensor, a missing value or nothing."""
+    if value_kind == "tensor":
+        value = np.zeros(TENSOR_SHAPE)
+    elif value_kind == "missing":
+        value = None
+    else:
+        value = TensorExtensionArray.from_stack(stack[:0])
+    array[key] = value
     assert_array_equal(array.to_stack(), stack)
+
+
+def test___setitem___with_empty_key_still_validates_value(array):
+    """Test that a sequence of the wrong length is rejected even when nothing is selected."""
+    with pytest.raises(ValueError, match="Cannot set 0 elements from a sequence of length 2"):
+        array[np.zeros(4, dtype=bool)] = [np.zeros(TENSOR_SHAPE), np.zeros(TENSOR_SHAPE)]
 
 
 def test___setitem___single_tensor_to_all_rows(array):
@@ -711,9 +748,9 @@ def test_pickability(array_with_missing):
 
 def test_pickle_slice_is_compact(dtype):
     """Test that pickling a slice does not serialize the whole parent buffer."""
-    big = TensorExtensionArray.from_stack(np.zeros((100_000, 8, 8)), dtype=None)
+    big = TensorExtensionArray.from_stack(np.zeros((10_000, 8, 8)))
     pickled = pickle.dumps(big[:10])
-    assert len(pickled) < 100_000
+    assert len(pickled) < 10 * 8 * 8 * 8 * 2  # about the ten rows of float64, not all 5 MB
     assert pickle.loads(pickled).equals(big[:10])
 
 
@@ -861,8 +898,6 @@ def test___arrow_array___with_type(array, stack):
     """Test conversion to arrow with an explicit type."""
     float32_type = pa.fixed_shape_tensor(pa.float32(), list(TENSOR_SHAPE))
     assert array.__arrow_array__(type=float32_type).type == float32_type
-    # pa.array() unwraps an extension type itself and asks for the storage type instead
-    assert pa.array(array, type=float32_type).type == float32_type.storage_type
     as_list = pa.array(array, type=pa.list_(pa.float64(), 6))
     assert as_list.type == pa.list_(pa.float64(), 6)
     assert as_list[0].as_py() == stack[0].reshape(-1).tolist()
@@ -989,27 +1024,3 @@ def test_series_apply_udf_argument(array, stack):
     assert_array_equal(result.to_numpy(), stack.sum(axis=(1, 2)))
     result = pd.Series(array).map(lambda t: t.shape)
     assert result.tolist() == [TENSOR_SHAPE] * 4
-
-
-def test_series_interpolate_not_implemented(array_with_missing):
-    """Test that interpolation is not supported, as for nested columns."""
-    with pytest.raises(NotImplementedError):
-        pd.Series(array_with_missing).interpolate()
-
-
-def test__from_sequence_of_strings_not_implemented(dtype):
-    """Test that constructing from strings is not supported."""
-    with pytest.raises(AbstractMethodError):
-        TensorExtensionArray._from_sequence_of_strings(["[1, 2]"], dtype=dtype)
-
-
-def test__from_factorized_not_implemented(array):
-    """Test that factorization is not supported, since tensors are not hashable."""
-    with pytest.raises(AbstractMethodError):
-        TensorExtensionArray._from_factorized(array.to_numpy(), array)
-
-
-def test_zero_copy_helpers(stack):
-    """Test the conftest helpers give distinct tensors of the expected shape."""
-    assert tensor(0).shape == TENSOR_SHAPE
-    assert not np.array_equal(stack[0], stack[1])


### PR DESCRIPTION
Adds the `TensorExtensionArray` class with the array for the TensorDType. Inspired heavily by the nested extension array.

Some points about it:
- Series-level assignment of a single tensor via loc/iloc, broadcasting, and fillna with a tensor don't work, because pandas inspects ndarray values before the extension array is consulted. Plain `series[label] = tensor`, sequences, and everything at the array level work. This is what #539 and #542 will address at the TensorSeries/NestedFrame level.
- unique, value_counts, factorize, merge and hashing don't work, since ndarrays aren't hashable. Same as nested with DataFrames.
- Nullable tensor columns don't round-trip Parquet before pyarrow 26.0.0 (apache/arrow#35692 and apache/arrow#35697, fixed 2026-07-28). Verified working on the 26.0.0 nightly and failing on 25.0.1. The round-trip test drops nulls until then.
- Non-identity permutations are rejected; identity ones are normalised away. pyarrow's own `FixedShapeTensorArray.from_numpy_ndarray` always stamps an identity permutation, so it has to be accepted, and pyarrow hashes those types differently despite comparing them equal, which is why it is normalised rather than just tolerated.
- Element-level nulls inside a tensor (which only arrow input can produce) read as NaN, upcasting integer tensors to float, as numpy and pandas do for missing numeric data. Row-level nulls are `pd.NA` as usual.
- read_parquet integration is to come later, new issue #552 for this.
- Some methods in nested were overwriting superclass methods just to call the method and raise errors for not being implemented. I dropped those since they're inherited anyway: they only called `super()`, which raises `AbstractMethodError`, so behaviour is identical with or without them. If they have a reason to be there I can add them back.
- `replace_with_mask` moved from `series/ext_array.py` to `series/utils.py` unchanged, since both arrays use it.
- `pyproject.toml`: mypy `mypy_path`/`explicit_package_bases` so the two `conftest.py` files under `tests/` don't collide.

Testing  runs pandas' extension-array conformance suite (`pandas.tests.extension.base`, 11 suites) alongside individual tests mirroring nested's. The 54 xfails are listed by reason in `tests/nested_pandas/tensors/conftest.py`.
